### PR TITLE
Catch Elasticsearch errors

### DIFF
--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -1,0 +1,18 @@
+from rest_framework import status
+from rest_framework.response import Response
+from elasticsearch import TransportError
+
+def catch_es_error(function):
+    def wrap(request, *args, **kwargs):
+        try:
+            return function(request, *args, **kwargs)
+        except TransportError as e:
+            status_code = e.status_code if isinstance(e.status_code, int) \
+                else status.HTTP_400_BAD_REQUEST
+            res = {
+                "error": 'Elasticsearch error: ' + e.error
+            }
+            return Response(res, status=status_code)
+    wrap.__doc__ = function.__doc__
+    wrap.__name__ = function.__name__
+    return wrap

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,11 +1,9 @@
 import os
-import sys
 import urllib
 import json
 from collections import defaultdict, namedtuple
 import requests
-from elasticsearch import Elasticsearch, TransportError
-
+from elasticsearch import Elasticsearch
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'), 
     os.environ.get('ES_PORT', '9200'))

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,9 +1,11 @@
 import os
+import sys
 import urllib
 import json
 from collections import defaultdict, namedtuple
 import requests
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, TransportError
+
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'), 
     os.environ.get('ES_PORT', '9200'))

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 from unittest import skip
+from elasticsearch import TransportError
 import mock
 from complaint_search.es_interface import document
 
@@ -21,3 +22,21 @@ class DocumentTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_esdocument.assert_called_once_with("123456")
         self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.document')
+    def test_document__transport_error_with_status_code(self, mock_esdocument):
+        mock_esdocument.side_effect = TransportError(status.HTTP_404_NOT_FOUND, "Error")
+        url = reverse('complaint_search:document', kwargs={"id": "123456"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
+
+    @mock.patch('complaint_search.es_interface.document')
+    def test_document__transport_error_without_status_code(self, mock_esdocument):
+        mock_esdocument.side_effect = TransportError('N/A', "Error")
+        url = reverse('complaint_search:document', kwargs={"id": "123456"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
+
+


### PR DESCRIPTION
This PR includes code to catch any elasticsearch errors from the es_interface, and handle them gracefully with 400 errors.  This should prevent any unnecessary 500 error for the user.

## Additions:
- Add try/catch block for all endpoints to handle Elasticsearch Transport errors