### PR TITLE
Add meta information

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -186,6 +186,7 @@ class AggregationBuilder(BaseBuilder):
             Field('tag', 100, False),
             Field('submitted_via', 100, False)
         ]
+
         aggs = {}
 
         # Creating aggregation object for each field above

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from complaint_search.es_interface import _ES_URL, _COMPLAINT_ES_INDEX, _COMPLAINT_DOC_TYPE, _ES_USER, _ES_PASSWORD, search, suggest, document
+from complaint_search.es_interface import _ES_URL, _COMPLAINT_ES_INDEX, _COMPLAINT_DOC_TYPE, _ES_USER, _ES_PASSWORD, get_meta, search, suggest, document
 from elasticsearch import Elasticsearch
 import requests
 import os
@@ -9,6 +9,30 @@ import deep
 import mock
 
 class EsInterfaceTest(TestCase):
+    # -------------------------------------------------------------------------
+    # Helper Attributes
+    # -------------------------------------------------------------------------
+    MOCK_SEARCH_SIDE_EFFECT = [
+        {"search" : "OK"}, 
+        {
+            "aggregations": {
+                "max_date": {
+                    "value_as_string": "2017-01-01"
+                }
+            }
+        }
+    ]
+
+    MOCK_COUNT_RETURN_VALUE = { "count": 100 }
+
+    MOCK_SEARCH_RESULT = {
+        'search': 'OK', 
+        '_meta': {
+            'total_record_count': 100, 
+            'last_updated': '2017-01-01', 
+            'license': 'CC0'
+        }
+    }
     # -------------------------------------------------------------------------
     # Helper Methods
     # -------------------------------------------------------------------------
@@ -25,24 +49,37 @@ class EsInterfaceTest(TestCase):
         with open(fileName, 'r') as f:
             return json.load(f)
 
+
     def setUp(self):
         pass
 
+    @mock.patch.object(Elasticsearch, 'search')
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_get_meta(self, mock_count, mock_search):
+        mock_search.return_value = self.MOCK_SEARCH_SIDE_EFFECT[1]
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+
+        res = get_meta()
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT["_meta"], res)
+
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
+    @mock.patch.object(Elasticsearch, 'count')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_no_param__valid(self, mock_rget, mock_search):
-        mock_search.return_value = 'OK'
+    def test_search_no_param__valid(self, mock_rget, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_no_param__valid")
         res = search()
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_rget.assert_not_called()
-        self.assertEqual('OK', res)
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._ES_URL", "ES_URL")
     @mock.patch("complaint_search.es_interface._ES_USER", "ES_USER")
@@ -81,17 +118,20 @@ class EsInterfaceTest(TestCase):
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_field__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_field__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_field__valid")
         res = search(field="test_field")
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
@@ -104,34 +144,43 @@ class EsInterfaceTest(TestCase):
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_size__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_size__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_size__valid")
         res = search(size=40)
-        mock_search.assert_called_once_with(body=body,
-            index="INDEX")
-        self.assertEqual('OK', res)
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_frm__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_frm__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_frm__valid")
         res = search(frm=20)
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
  
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_sort__valid(self, mock_search):
-        mock_search.return_value = 'OK'
-        body = self.load("search_with_sort__valid")
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_sort__valid(self, mock_count, mock_search):
 
         sort_fields = [
             ("relevance_desc", "_score", "desc"), 
@@ -139,308 +188,358 @@ class EsInterfaceTest(TestCase):
             ("created_date_desc", "created_date", "desc"), 
             ("created_date_asc", "created_date", "asc")
         ]
+
+        # 4 is the length of sort_field
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT * 4
+        mock_count.side_effect = [self.MOCK_COUNT_RETURN_VALUE] * 4
+        body = self.load("search_with_sort__valid")
+
         for s in sort_fields:
             res = search(sort=s[0])
             body["sort"] = [{s[1]: {"order": s[2]}}]
             mock_search.assert_any_call(body=body, index="INDEX")
-            self.assertEqual('OK', res)
+            self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
-        self.assertEqual(4, mock_search.call_count)
+        self.assertEqual(8, mock_search.call_count)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_search_term__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_search_term__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term__valid")
         res = search(search_term="test_term")
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_min_date__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_min_date__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_min_date__valid")
         res = search(min_date="2014-04-14")
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_max_date__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_max_date__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_max_date__valid")
         res = search(max_date="2017-04-14")
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_company__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_company__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_company__valid")
         res = search(company=["Bank 1", "Second Bank"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "company"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_product__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_product__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_product__valid")
         res = search(product=["Payday Loan", u"Mortgage\u2022FHA Mortgage"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "product"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)  
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_issue__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_issue__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_issue__valid")
         res = search(issue=[u"Communication tactics\u2022Frequent or repeated calls",
         "Loan servicing, payments, escrow account"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "issue"
             diff.print_full()
-            print "body"
-            print body
-            print "act_body"
-            print act_body
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)  
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)  
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_state__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_state__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_state__valid")
         res = search(state=["CA", "VA", "OR"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "state"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_zip_code__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_zip_code__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_zip_code__valid")
         res = search(zip_code=["12345", "23435", "03433"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "zip_code"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_timely__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_timely__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_timely__valid")
         res = search(timely=["Yes", "No"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "timely"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_company_response__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_company_response__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_company_response__valid")
         res = search(company_response=["Closed", "No response"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "company_response"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
         
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_company_public_response__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_company_public_response__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_company_public_response__valid")
         res = search(company_public_response=["Response 1", "Response 2"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "company_public_response.raw"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_consumer_consent_provided__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_consumer_consent_provided__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_consumer_consent_provided__valid")
         res = search(consumer_consent_provided=["yes", "no"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "consumer_consent_provided.raw"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_submitted_via__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_submitted_via__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_submitted_via__valid")
         res = search(submitted_via=["mail", "web"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "submitted_via"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_tag__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_tag__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_tag__valid")
         res = search(tag=["Older American", "Servicemember"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "tag"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_consumer_disputed__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_consumer_disputed__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_consumer_disputed__valid")
         res = search(consumer_disputed=["No", "Yes"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "consumer_disputed"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
-    def test_search_with_has_narratives__valid(self, mock_search):
-        mock_search.return_value = 'OK'
+    @mock.patch.object(Elasticsearch, 'count')
+    def test_search_with_has_narratives__valid(self, mock_count, mock_search):
+        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_has_narratives__valid")
         res = search(has_narratives=["No", "Yes"])
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(2, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(2, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
         diff = deep.diff(body, act_body)
         if diff:
             print "has_narratives"
             diff.print_full()
         self.assertIsNone(deep.diff(body, act_body))
-        self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")


### PR DESCRIPTION
Provide license, date, count information in the API results.

## Additions
- Create meta info in json by querying max_date and count info from elasticsearch

## Notes
- This PR does not include adding meta info for csv, xls, and xlsx