### PR TITLE
Add no_aggs parameter for JSON

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -88,7 +88,8 @@ class SearchBuilder(BaseBuilder):
             "field": "complaint_what_happened", 
             "size": 10, 
             "frm": 0,
-            "sort": "relevance_desc"
+            "sort": "relevance_desc",
+            "no_aggs": False
         }
 
     def build(self):

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -72,9 +72,10 @@ def search(**kwargs):
     res = None
     format = kwargs.get("format", "json")
     if format == "json":
-        aggregation_builder = AggregationBuilder()
-        aggregation_builder.add(**kwargs)
-        body["aggs"] = aggregation_builder.build()
+        if not kwargs.get("no_aggs", False):
+            aggregation_builder = AggregationBuilder()
+            aggregation_builder.add(**kwargs)
+            body["aggs"] = aggregation_builder.build()
 
         res = get_es().search(index=_COMPLAINT_ES_INDEX, doc_type=_COMPLAINT_DOC_TYPE, body=body, scroll="10m")
 

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -42,11 +42,11 @@ class SearchInputSerializer(serializers.Serializer):
         (SORT_CREATED_DATE_DESC, 'Descending Created Date'),
         (SORT_CREATED_DATE_ASC, 'Ascending Created Date'),
     )
-    format = serializers.ChoiceField(FORMAT_CHOICES, required=False)
-    field = serializers.ChoiceField(FIELD_CHOICES, required=False)
-    size = serializers.IntegerField(min_value=1, max_value=100000, required=False)
-    frm = serializers.IntegerField(min_value=0, max_value=100000, required=False)
-    sort = serializers.ChoiceField(SORT_CHOICES, required=False)
+    format = serializers.ChoiceField(FORMAT_CHOICES, default=FORMAT_JSON)
+    field = serializers.ChoiceField(FIELD_CHOICES, default=FIELD_NARRATIVE)
+    size = serializers.IntegerField(min_value=1, max_value=100000, default=10)
+    frm = serializers.IntegerField(min_value=0, max_value=100000, default=0)
+    sort = serializers.ChoiceField(SORT_CHOICES, default=SORT_RELEVANCE_DESC)
     search_term = serializers.CharField(max_length=200, required=False)
     min_date = serializers.DateField(required=False)
     max_date = serializers.DateField(required=False)
@@ -76,6 +76,7 @@ class SearchInputSerializer(serializers.Serializer):
         child=serializers.CharField(max_length=200), required=False)
     tag = serializers.ListField(
         child=serializers.CharField(max_length=200), required=False)
+    no_aggs = serializers.BooleanField(default=False)
 
     def to_internal_value(self, data):
         ret = super(SearchInputSerializer, self).to_internal_value(data)

--- a/complaint_search/tests/test_serializer.py
+++ b/complaint_search/tests/test_serializer.py
@@ -11,7 +11,20 @@ class SearchInputSerializerTests(TestCase):
     def test_is_valid__no_args(self):
         serializer = SearchInputSerializer(data={})
         self.assertTrue(serializer.is_valid())
-        self.assertEqual({}, serializer.validated_data)
+        exp_dict = {
+            "format": "json", 
+            "field": "complaint_what_happened", 
+            "size": 10, 
+            "frm": 0, 
+            "no_aggs": False, 
+            "search_term": "complaint_what_happened",
+            "sort": "relevance_desc"
+        }
+        # This is an OrderedDict
+        for k, v in serializer.validated_data.iteritems():
+
+            self.assertIn(k, exp_dict)
+            self.assertEqual(v, exp_dict[k])
 
     def test_is_valid__valid_product(self):
         self.data['product'] = [u"Mortgage\u2022FHA Mortgage", "Payday Loan"]

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -23,7 +23,16 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_essearch.assert_called_once_with()
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc"
+                }
+            )
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -74,7 +83,13 @@ class SearchTests(APITestCase):
             self.assertEqual('OK', response.data)
 
         calls = [ mock.call(
-            **{"field": SearchInputSerializer.FIELD_MAP.get(field_pair[0], 
+            **{
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "field": SearchInputSerializer.FIELD_MAP.get(field_pair[0], 
                 field_pair[0])}) 
                 for field_pair in SearchInputSerializer.FIELD_CHOICES ]
         mock_essearch.assert_has_calls(calls)
@@ -97,7 +112,14 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**{"size": 4})
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "sort": "relevance_desc", 
+                "size": 4})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -138,11 +160,20 @@ class SearchTests(APITestCase):
     @mock.patch('complaint_search.es_interface.search')
     def test_search_with_frm__valid(self, mock_essearch):
         url = reverse('complaint_search:search')
-        params = {"frm": 4}
+        params = { "frm": 4 }
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**{"frm": 4})
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 4, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc"
+            }
+        )
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -190,7 +221,15 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(**{"sort": sort_pair[0]}) 
+        calls = [ mock.call(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "sort": sort_pair[0]}) 
             for sort_pair in SearchInputSerializer.SORT_CHOICES ]
         mock_essearch.assert_has_calls(calls)
 
@@ -212,7 +251,15 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**params)
+        mock_essearch.assert_called_once_with(**{
+            "field": "complaint_what_happened", 
+            "format": "json", 
+            "frm": 0, 
+            "no_aggs": False, 
+            "size": 10, 
+            "sort": "relevance_desc", 
+            "search_term": "FHA Mortgage"
+        })
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -222,7 +269,15 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**{"min_date": date(2017, 04, 11)})
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "min_date": date(2017, 04, 11)})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -243,7 +298,15 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**{"max_date": date(2017, 04, 11)})
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "max_date": date(2017, 04, 11)})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -264,7 +327,15 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**{"company": ["One Bank", "Bank 2"]})
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "company": ["One Bank", "Bank 2"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -278,7 +349,14 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         mock_essearch.assert_called_once_with(
-            **{"product": ["Mortgage-FHA Mortgage", "Payday Loan"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "product": ["Mortgage-FHA Mortgage", "Payday Loan"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -294,7 +372,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"issue": ["Communication tactics-Frequent or repeated calls", 
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "issue": ["Communication tactics-Frequent or repeated calls", 
             "Loan servicing, payments, escrow account"]})
         self.assertEqual('OK', response.data)
 
@@ -307,7 +392,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"state": ["CA", "FL", "VA"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "state": ["CA", "FL", "VA"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -319,7 +411,16 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"zip_code": ["94XXX", "24236", "23456"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "zip_code": ["94XXX", "24236", "23456"]
+            }
+        )
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -331,7 +432,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"timely": ["YES", "NO"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "timely": ["YES", "NO"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -343,7 +451,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"consumer_disputed": ["yes", "no"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "consumer_disputed": ["yes", "no"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -355,7 +470,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"company_response": ["Closed", "No response"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "company_response": ["Closed", "No response"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -367,7 +489,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"company_public_response": ["Closed", "No response"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "company_public_response": ["Closed", "No response"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -379,7 +508,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"consumer_consent_provided": ["Yes", "No"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "consumer_consent_provided": ["Yes", "No"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -391,7 +527,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"has_narratives": ["Yes", "No"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "has_narratives": ["Yes", "No"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -403,7 +546,14 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"submitted_via": ["Web", "Phone"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "submitted_via": ["Web", "Phone"]})
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -415,8 +565,43 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
         mock_essearch.assert_called_once_with(
-            **{"tag": ["Older American", "Servicemember"]})
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": False, 
+                "size": 10, 
+                "sort": "relevance_desc", 
+                "tag": ["Older American", "Servicemember"]})
         self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_no_aggs__valid(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = {"no_aggs": True}
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        mock_essearch.assert_called_once_with(
+            **{
+                "field": "complaint_what_happened", 
+                "format": "json", 
+                "frm": 0, 
+                "no_aggs": True, 
+                "sort": "relevance_desc", 
+                "size": 10})
+        self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_no_aggs__invalid_type(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = {"no_aggs": "Not boolean"}
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        mock_essearch.assert_not_called()
+        self.assertDictEqual({"no_aggs": [u'"Not boolean" is not a valid boolean.']}, 
+            response.data)
 
     @mock.patch('complaint_search.es_interface.search')
     def test_search__transport_error_with_status_code(self, mock_essearch):

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -14,6 +14,19 @@ class SearchTests(APITestCase):
     def setUp(self):
         pass
 
+    def buildDefaultParams(self, overrides):
+        params = {
+            "field": "complaint_what_happened", 
+            "format": "json", 
+            "frm": 0, 
+            "no_aggs": False, 
+            "size": 10, 
+            "sort": "relevance_desc"
+        }
+
+        params.update(overrides)
+        return params
+
     @mock.patch('complaint_search.es_interface.search')
     def test_search_no_param(self, mock_essearch):
         """
@@ -23,16 +36,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc"
-                }
-            )
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -82,16 +86,10 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(
-            **{
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "field": SearchInputSerializer.FIELD_MAP.get(field_pair[0], 
-                field_pair[0])}) 
-                for field_pair in SearchInputSerializer.FIELD_CHOICES ]
+        calls = [ mock.call(**self.buildDefaultParams({
+            "field": SearchInputSerializer.FIELD_MAP.get(field_pair[0], 
+                field_pair[0])}))
+            for field_pair in SearchInputSerializer.FIELD_CHOICES ]
         mock_essearch.assert_has_calls(calls)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -112,14 +110,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "sort": "relevance_desc", 
-                "size": 4})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -164,16 +155,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 4, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc"
-            }
-        )
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -221,15 +203,7 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "sort": sort_pair[0]}) 
+        calls = [ mock.call(**self.buildDefaultParams({"sort": sort_pair[0]}))
             for sort_pair in SearchInputSerializer.SORT_CHOICES ]
         mock_essearch.assert_has_calls(calls)
 
@@ -251,15 +225,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**{
-            "field": "complaint_what_happened", 
-            "format": "json", 
-            "frm": 0, 
-            "no_aggs": False, 
-            "size": 10, 
-            "sort": "relevance_desc", 
-            "search_term": "FHA Mortgage"
-        })
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -269,15 +235,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "min_date": date(2017, 04, 11)})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+            "min_date": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -298,15 +257,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "max_date": date(2017, 04, 11)})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+            "max_date": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -327,15 +279,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "company": ["One Bank", "Bank 2"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+            "company": ["One Bank", "Bank 2"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -348,15 +293,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "product": ["Mortgage-FHA Mortgage", "Payday Loan"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+            "product": ["Mortgage-FHA Mortgage", "Payday Loan"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -371,16 +309,9 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
                 "issue": ["Communication tactics-Frequent or repeated calls", 
-            "Loan servicing, payments, escrow account"]})
+            "Loan servicing, payments, escrow account"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -391,15 +322,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "state": ["CA", "FL", "VA"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "state": ["CA", "FL", "VA"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -410,17 +334,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "zip_code": ["94XXX", "24236", "23456"]
-            }
-        )
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "zip_code": ["94XXX", "24236", "23456"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -431,15 +346,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "timely": ["YES", "NO"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "timely": ["YES", "NO"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -450,15 +358,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "consumer_disputed": ["yes", "no"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "consumer_disputed": ["yes", "no"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -469,15 +370,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "company_response": ["Closed", "No response"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({ 
+                "company_response": ["Closed", "No response"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -488,15 +382,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "company_public_response": ["Closed", "No response"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "company_public_response": ["Closed", "No response"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -507,15 +394,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "consumer_consent_provided": ["Yes", "No"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "consumer_consent_provided": ["Yes", "No"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -526,15 +406,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "has_narratives": ["Yes", "No"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "has_narratives": ["Yes", "No"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -545,15 +418,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "submitted_via": ["Web", "Phone"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "submitted_via": ["Web", "Phone"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -564,15 +430,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": False, 
-                "size": 10, 
-                "sort": "relevance_desc", 
-                "tag": ["Older American", "Servicemember"]})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "tag": ["Older American", "Servicemember"]}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -582,14 +441,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(
-            **{
-                "field": "complaint_what_happened", 
-                "format": "json", 
-                "frm": 0, 
-                "no_aggs": True, 
-                "sort": "relevance_desc", 
-                "size": 10})
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+                "no_aggs": True}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')

--- a/complaint_search/tests/test_views_suggest.py
+++ b/complaint_search/tests/test_views_suggest.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -75,6 +76,18 @@ class SuggestTests(APITestCase):
         self.assertDictEqual(
             {"size": ["Ensure this value is less than or equal to 100000."]}, 
             response.data)
+
+    @mock.patch('complaint_search.es_interface.suggest')
+    def test_suggest_cors_headers(self, mock_essuggest):
+        """
+        Make sure the response has CORS headers in debug mode
+        """
+        settings.DEBUG = True
+        url = reverse('complaint_search:suggest')
+        mock_essuggest.return_value = 'OK'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
 
     @mock.patch('complaint_search.es_interface.suggest')
     def test_suggest__transport_error_with_status_code(self, mock_essuggest):

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -18,8 +18,12 @@ from complaint_search.serializer import SearchInputSerializer, SuggestInputSeria
 def search(request):
 
     fixed_qparam = request.query_params
+    
+    # When you add a query parameter, make sure you add it to one of the 
+    # constant tuples below so it will be parse correctly
+
     QPARAMS_VARS = ('fmt', 'field', 'size', 'frm', 'sort', 
-        'search_term', 'min_date', 'max_date')
+        'search_term', 'min_date', 'max_date', 'no_aggs')
 
     QPARAMS_LISTS = ('company', 'product', 'issue', 'state', 
         'zip_code', 'timely', 'consumer_disputed', 'company_response',


### PR DESCRIPTION
`no_aggs` is a new query parameter uses to indicate if we are outputting aggregations or not for JSON.
`no_aggs = True` means no aggregations will be displayed.
`no_aggs = False` means aggregations will be displayed.

`no_aggs = False` is the default value, which means that if `no_aggs` is not passed in as a query parameter, aggregations will be displayed by default.

Note that this parameter will only work for JSON format, since other formats, by default, no aggregations will be included.

## Additions:
- Added `no_aggs` with a default of `False` in serializer
- Added appropriate tests

## Changes:
- Changed some serializer fields to have default values and changed corresponding tests