### PR TITLE
Fix Pagination

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -1,0 +1,8 @@
+PARAMS = {
+    "format": "json", 
+    "field": "complaint_what_happened", 
+    "size": 10, 
+    "frm": 0,
+    "sort": "relevance_desc",
+    "no_aggs": False
+}

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -1,5 +1,7 @@
+import copy
 import abc
 from collections import defaultdict, namedtuple
+from complaint_search.defaults import PARAMS
 
 class BaseBuilder(object):
     __metaclass__  = abc.ABCMeta
@@ -83,14 +85,7 @@ class BaseBuilder(object):
 
 class SearchBuilder(BaseBuilder):
     def __init__(self):
-        self.params = {
-            "format": "json", 
-            "field": "complaint_what_happened", 
-            "size": 10, 
-            "frm": 0,
-            "sort": "relevance_desc",
-            "no_aggs": False
-        }
+        self.params = copy.deepcopy(PARAMS)
 
     def build(self):
         search = {

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,10 +1,12 @@
 import os
 import urllib
 import json
+import copy
 from collections import defaultdict, namedtuple
 import requests
 from elasticsearch import Elasticsearch
 from complaint_search.es_builders import SearchBuilder, PostFilterBuilder, AggregationBuilder
+from complaint_search.defaults import PARAMS
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'), 
     os.environ.get('ES_PORT', '9200'))
@@ -59,25 +61,38 @@ def get_meta():
 # - submitted_via: filters a list of ways the complaint was submitted
 # - tag - filters a list of tags
 def search(**kwargs):
-
+    params = copy.deepcopy(PARAMS)
+    params.update(**kwargs)
     search_builder = SearchBuilder()
-    search_builder.add(**kwargs)
+    search_builder.add(**params)
     body = search_builder.build()
 
     post_filter_builder = PostFilterBuilder()
-    post_filter_builder.add(**kwargs)
+    post_filter_builder.add(**params)
     body["post_filter"] = post_filter_builder.build()
 
     # format
     res = None
-    format = kwargs.get("format", "json")
+    format = params.get("format")
     if format == "json":
-        if not kwargs.get("no_aggs", False):
+        if not params.get("no_aggs"):
             aggregation_builder = AggregationBuilder()
-            aggregation_builder.add(**kwargs)
+            aggregation_builder.add(**params)
             body["aggs"] = aggregation_builder.build()
 
-        res = get_es().search(index=_COMPLAINT_ES_INDEX, doc_type=_COMPLAINT_DOC_TYPE, body=body, scroll="10m")
+        res = get_es().search(index=_COMPLAINT_ES_INDEX, 
+            doc_type=_COMPLAINT_DOC_TYPE, 
+            body=body, 
+            scroll="10m")
+
+        num_of_scroll = params.get("frm") / params.get("size")
+
+        scroll_id = res['_scroll_id']
+        if num_of_scroll > 0:
+            while num_of_scroll > 0:
+                res['hits']['hits'] = get_es().scroll(scroll_id=scroll_id, 
+                    scroll="10m")['hits']['hits']
+                num_of_scroll -= 1
 
         res["_meta"] = get_meta()
 

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from localflavor.us.us_states import STATE_CHOICES
+from complaint_search.defaults import PARAMS
 
 class SearchInputSerializer(serializers.Serializer):
 
@@ -42,11 +43,11 @@ class SearchInputSerializer(serializers.Serializer):
         (SORT_CREATED_DATE_DESC, 'Descending Created Date'),
         (SORT_CREATED_DATE_ASC, 'Ascending Created Date'),
     )
-    format = serializers.ChoiceField(FORMAT_CHOICES, default=FORMAT_JSON)
-    field = serializers.ChoiceField(FIELD_CHOICES, default=FIELD_NARRATIVE)
-    size = serializers.IntegerField(min_value=1, max_value=100000, default=10)
-    frm = serializers.IntegerField(min_value=0, max_value=100000, default=0)
-    sort = serializers.ChoiceField(SORT_CHOICES, default=SORT_RELEVANCE_DESC)
+    format = serializers.ChoiceField(FORMAT_CHOICES, default=PARAMS['format'])
+    field = serializers.ChoiceField(FIELD_CHOICES, default=PARAMS['field'])
+    size = serializers.IntegerField(min_value=1, max_value=100000, default=PARAMS['size'])
+    frm = serializers.IntegerField(min_value=0, max_value=100000, default=PARAMS['frm'])
+    sort = serializers.ChoiceField(SORT_CHOICES, default=PARAMS['sort'])
     search_term = serializers.CharField(max_length=200, required=False)
     min_date = serializers.DateField(required=False)
     max_date = serializers.DateField(required=False)
@@ -76,7 +77,7 @@ class SearchInputSerializer(serializers.Serializer):
         child=serializers.CharField(max_length=200), required=False)
     tag = serializers.ListField(
         child=serializers.CharField(max_length=200), required=False)
-    no_aggs = serializers.BooleanField(default=False)
+    no_aggs = serializers.BooleanField(default=PARAMS['no_aggs'])
 
     def to_internal_value(self, data):
         ret = super(SearchInputSerializer, self).to_internal_value(data)
@@ -109,6 +110,14 @@ class SearchInputSerializer(serializers.Serializer):
                     raise serializers.ValidationError(u"Issue is malformed, it needs to be \"issue\" or \"issue\u2022subissue\"")
 
         return value
+
+    def validate(self, data):
+        """
+        Check that from is a multiple of size
+        """
+        if data['frm'] % data['size'] != 0:
+            raise serializers.ValidationError("frm is not zero or a multiple of size")
+        return data
 
 class SuggestInputSerializer(serializers.Serializer):
     text = serializers.CharField(max_length=200, required=False)

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -3,6 +3,7 @@ from complaint_search.es_interface import _ES_URL, _COMPLAINT_ES_INDEX, _COMPLAI
 from elasticsearch import Elasticsearch
 import requests
 import os
+import copy
 import urllib
 import json
 import deep
@@ -13,7 +14,13 @@ class EsInterfaceTest(TestCase):
     # Helper Attributes
     # -------------------------------------------------------------------------
     MOCK_SEARCH_SIDE_EFFECT = [
-        {"search" : "OK"}, 
+        {
+            "search" : "OK", 
+            "_scroll_id": "This_is_a_scroll_id",
+            "hits": {
+                "hits": [0, 1, 2, 3]
+            }
+        }, 
         {
             "aggregations": {
                 "max_date": {
@@ -27,12 +34,29 @@ class EsInterfaceTest(TestCase):
 
     MOCK_SEARCH_RESULT = {
         'search': 'OK', 
+        "_scroll_id": "This_is_a_scroll_id",
+        "hits": {
+            "hits": [0, 1, 2, 3]
+        },
         '_meta': {
             'total_record_count': 100, 
             'last_updated': '2017-01-01', 
             'license': 'CC0'
         }
     }
+
+    MOCK_SCROLL_SIDE_EFFECT = [
+        {
+            "hits": {
+                "hits": [4, 5, 6, 7]
+            }
+        }, 
+        {
+            "hits": {
+                "hits": [8, 9, 10, 11]
+            }
+        }
+    ]
     # -------------------------------------------------------------------------
     # Helper Methods
     # -------------------------------------------------------------------------
@@ -65,10 +89,12 @@ class EsInterfaceTest(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
+    @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_no_param__valid(self, mock_rget, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    def test_search_no_param__valid(self, mock_rget, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = self.load("search_no_param__valid")
         res = search()
         self.assertEqual(2, len(mock_search.call_args_list))
@@ -78,8 +104,9 @@ class EsInterfaceTest(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         mock_rget.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._ES_URL", "ES_URL")
     @mock.patch("complaint_search.es_interface._ES_USER", "ES_USER")
@@ -119,9 +146,11 @@ class EsInterfaceTest(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_field__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_field__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = self.load("search_with_field__valid")
         res = search(field="test_field")
         self.assertEqual(2, len(mock_search.call_args_list))
@@ -131,7 +160,8 @@ class EsInterfaceTest(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+        mock_scroll.assert_not_called()
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
@@ -145,8 +175,9 @@ class EsInterfaceTest(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_size__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_size__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_size__valid")
         res = search(size=40)
@@ -157,14 +188,17 @@ class EsInterfaceTest(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+        mock_scroll.assert_not_called()
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_frm__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_frm__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        mock_scroll.side_effect = copy.deepcopy(self.MOCK_SCROLL_SIDE_EFFECT)
         body = self.load("search_with_frm__valid")
         res = search(frm=20)
         self.assertEqual(2, len(mock_search.call_args_list))
@@ -174,13 +208,17 @@ class EsInterfaceTest(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+        self.assertEqual(mock_scroll.call_count, 2)
+        search_result = copy.deepcopy(self.MOCK_SEARCH_RESULT)
+        search_result['hits']['hits'] = self.MOCK_SCROLL_SIDE_EFFECT[1]['hits']['hits']
+        self.assertDictEqual(search_result, res)
 
  
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_sort__valid(self, mock_count, mock_search):
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_sort__valid(self, mock_scroll, mock_count, mock_search):
 
         sort_fields = [
             ("relevance_desc", "_score", "desc"), 
@@ -190,8 +228,15 @@ class EsInterfaceTest(TestCase):
         ]
 
         # 4 is the length of sort_field
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT * 4
-        mock_count.side_effect = [self.MOCK_COUNT_RETURN_VALUE] * 4
+        # mock_search.side_effect = []
+        # mock_count.side_effect = []
+        # for i in range(4):
+
+        # This create copies of MOCK_SEARCH_SIDE_EFFECT 4 times, and flatten the list out
+        mock_search.side_effect = [ item for sublist in [ copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT) 
+            for i in range(4) ] for item in sublist ]
+        mock_count.side_effect = [ copy.deepcopy(self.MOCK_COUNT_RETURN_VALUE) 
+            for i in range(4) ]
         body = self.load("search_with_sort__valid")
 
         for s in sort_fields:
@@ -200,13 +245,15 @@ class EsInterfaceTest(TestCase):
             mock_search.assert_any_call(body=body, index="INDEX", doc_type=_COMPLAINT_DOC_TYPE, scroll="10m")
             self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
+        mock_scroll.assert_not_called()
         self.assertEqual(8, mock_search.call_count)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_search_term_match__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_search_term_match__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term_match__valid")
         res = search(search_term="test_term")
@@ -221,13 +268,15 @@ class EsInterfaceTest(TestCase):
             diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_search_term_qsq_and__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_search_term_qsq_and__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term_qsq_and__valid")
         res = search(search_term="test AND term")
@@ -242,13 +291,15 @@ class EsInterfaceTest(TestCase):
             diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_search_term_qsq_or__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_search_term_qsq_or__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term_qsq_or__valid")
         res = search(search_term="test OR term")
@@ -263,13 +314,15 @@ class EsInterfaceTest(TestCase):
             diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_search_term_qsq_not__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_search_term_qsq_not__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term_qsq_not__valid")
         res = search(search_term="test NOT term")
@@ -284,13 +337,15 @@ class EsInterfaceTest(TestCase):
             diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_search_term_qsq_to__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_search_term_qsq_to__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term_qsq_to__valid")
         res = search(search_term="term TO test")
@@ -305,13 +360,15 @@ class EsInterfaceTest(TestCase):
             diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_min_date__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_min_date__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_min_date__valid")
         res = search(min_date="2014-04-14")
@@ -322,13 +379,15 @@ class EsInterfaceTest(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_max_date__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_max_date__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_max_date__valid")
         res = search(max_date="2017-04-14")
@@ -339,13 +398,15 @@ class EsInterfaceTest(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_company__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_company__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_company__valid")
         res = search(company=["Bank 1", "Second Bank"])
@@ -361,14 +422,16 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_product__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_product__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_product__valid")
         res = search(product=["Payday Loan", u"Mortgage\u2022FHA Mortgage"])
@@ -384,13 +447,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_issue__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_issue__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_issue__valid")
         res = search(issue=[u"Communication tactics\u2022Frequent or repeated calls",
@@ -407,13 +472,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)  
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_state__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_state__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_state__valid")
         res = search(state=["CA", "VA", "OR"])
@@ -429,13 +496,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_zip_code__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_zip_code__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_zip_code__valid")
         res = search(zip_code=["12345", "23435", "03433"])
@@ -451,13 +520,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+        mock_scroll.assert_not_called()
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_timely__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_timely__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_timely__valid")
         res = search(timely=["Yes", "No"])
@@ -473,13 +544,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_company_response__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_company_response__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_company_response__valid")
         res = search(company_response=["Closed", "No response"])
@@ -495,13 +568,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
         
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_company_public_response__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_company_public_response__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_company_public_response__valid")
         res = search(company_public_response=["Response 1", "Response 2"])
@@ -517,13 +592,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_consumer_consent_provided__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_consumer_consent_provided__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_consumer_consent_provided__valid")
         res = search(consumer_consent_provided=["yes", "no"])
@@ -539,13 +616,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_submitted_via__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_submitted_via__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_submitted_via__valid")
         res = search(submitted_via=["mail", "web"])
@@ -561,13 +640,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_tag__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_tag__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_tag__valid")
         res = search(tag=["Older American", "Servicemember"])
@@ -583,13 +664,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_consumer_disputed__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_consumer_disputed__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_consumer_disputed__valid")
         res = search(consumer_disputed=["No", "Yes"])
@@ -605,13 +688,15 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_search_with_has_narratives__valid(self, mock_count, mock_search):
-        mock_search.side_effect = self.MOCK_SEARCH_SIDE_EFFECT
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_has_narratives__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_has_narratives__valid")
         res = search(has_narratives=["No", "Yes"])
@@ -627,6 +712,7 @@ class EsInterfaceTest(TestCase):
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
 

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -151,7 +151,7 @@ class SearchTests(APITestCase):
     @mock.patch('complaint_search.es_interface.search')
     def test_search_with_frm__valid(self, mock_essearch):
         url = reverse('complaint_search:search')
-        params = { "frm": 4 }
+        params = { "frm": 10 }
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -191,6 +191,18 @@ class SearchTests(APITestCase):
         mock_essearch.assert_not_called()
         self.assertDictEqual(
             {"frm": ["Ensure this value is less than or equal to 100000."]}, 
+            response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_frm__invalid_frm_not_multiples_of_size(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = { "frm": 4 }
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        mock_essearch.assert_not_called()
+        self.assertDictEqual(
+            {"non_field_errors": ["frm is not zero or a multiple of size"]}, 
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')


### PR DESCRIPTION
This PR fix issue #27.  It continues the use of scroll, but needs to scroll to the right "page" based on `frm`.  `frm` needs to be zero or a multiple of `size` to make this works.

## Additions:
- Added logic to scroll pages based on `frm`
- Added and fixed tests

## Changes:
- Pulled out default parameters to increase reusability

