### PR TITLE
Query String Query - Only route to match if it is alphanumeric and/or spaces

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -1,3 +1,4 @@
+import re
 import copy
 import abc
 from collections import defaultdict, namedtuple
@@ -114,28 +115,32 @@ class SearchBuilder(BaseBuilder):
         search["sort"] = [{sort_field: {"order": sort_order}}]
 
         # query
-        if self.params.get("search_term"):
-            if any(keyword in self.params.get("search_term") 
+        search_term = self.params.get("search_term")
+        if search_term:
+            if re.match("^[A-Za-z\d\s]+$", search_term) and \
+            not any(keyword in search_term 
                 for keyword in ("AND", "OR", "NOT", "TO")):
 
-                # QueryString Query
-                search["query"] = {
-                    "query_string": {
-                        "query": self.params.get("search_term"),
-                        "fields": [
-                            self.params.get("field")
-                        ],
-                        "default_operator": "AND"
-                    }
-                }
-            else: 
                 # Match Query
                 search["query"] = {
                     "match": {
                         self.params.get("field"): {
-                            "query": self.params.get("search_term"), 
+                            "query": search_term, 
                             "operator": "and"
                         }
+                    }
+                }
+
+            else: 
+
+                # QueryString Query
+                search["query"] = {
+                    "query_string": {
+                        "query": search_term,
+                        "fields": [
+                            self.params.get("field")
+                        ],
+                        "default_operator": "AND"
                     }
                 }
 

--- a/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
@@ -4,7 +4,7 @@
     "query": {
         "match": {
             "complaint_what_happened": {
-                "query": "test_term", 
+                "query": "test term", 
                 "operator": "and"
             }
         }

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -256,7 +256,7 @@ class EsInterfaceTest(TestCase):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         body = self.load("search_with_search_term_match__valid")
-        res = search(search_term="test_term")
+        res = search(search_term="test term")
         self.assertEqual(2, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))


### PR DESCRIPTION
Query string query wasn't working as expected as it is only routing to it when keyword AND/OR/NOT/TO are in the search_term.  It should be routed if it includes more than alphanumeric and spaces.

## Changes:
- Only route to match if alphanumeric and/or with spaces, else route to query string query