### PR TITLE
Date Filters

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -6,3 +6,6 @@ PARAMS = {
     "sort": "relevance_desc",
     "no_aggs": False
 }
+
+# -*- coding: utf-8 -*-
+DELIMITER = u'\u2022'

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -2,7 +2,7 @@ import re
 import copy
 import abc
 from collections import defaultdict, namedtuple
-from complaint_search.defaults import PARAMS
+from complaint_search.defaults import PARAMS, DELIMITER
 
 class BaseBuilder(object):
     __metaclass__  = abc.ABCMeta
@@ -15,6 +15,7 @@ class BaseBuilder(object):
     # Filters for those that need conversion from string to boolean
     _OPTIONAL_FILTERS_STRING_TO_BOOL = ("has_narrative",)
 
+    # Filters that use different names in Elasticsearch
     _OPTIONAL_FILTERS_PARAM_TO_ES_MAP = {
         "product": "product.raw",
         "sub_product": "sub_product.raw",
@@ -26,10 +27,20 @@ class BaseBuilder(object):
         "consumer_disputed": "consumer_disputed.raw"
     }
 
+    # Filters that have a child and this maps to their child's name
     _OPTIONAL_FILTERS_CHILD_MAP = {
         "product": "sub_product", 
         "issue": "sub_issue"
     }
+
+    def _get_es_name(self, field):
+        return self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(field, field)
+
+    def _has_child(self, field):
+        return field in self._OPTIONAL_FILTERS_CHILD_MAP
+
+    def _get_child(self, field):
+        return self._OPTIONAL_FILTERS_CHILD_MAP.get(field)
 
     def __init__(self):
         self.params = {}
@@ -41,21 +52,29 @@ class BaseBuilder(object):
     def build(self):
          """Method that will build the body dictionary."""
 
-    def _create_bool_should_clauses(self, es_field_name, value_list, 
-        with_subitems=False, es_subitem_field_name=None):
+    ## This create all the bool should filter clauses for a field
+    ## es_field_name: a field name (to be filtered in ES)
+    ## value_list: a list of values to be filtered for this field
+    ## with_child: set to true if this field has a child field
+    ## es_child_field_name: if with_child is true, this holds the field
+    ## name of the child used (to be filtered in ES)
+    def _build_bool_should_clauses(self, field):
+        es_field_name = self._get_es_name(field)
+        value_list = [ 0 if cd.lower() == "no" else 1 for cd in self.params[field] ] \
+            if field in self._OPTIONAL_FILTERS_STRING_TO_BOOL else self.params.get(field) 
         if value_list:
-            if not with_subitems:
+            if not self._has_child(field):
                 term_list = [ {"terms": {es_field_name: [value]}} 
                     for value in value_list ]
                 return {"bool": {"should": term_list}}
             else:
                 item_dict = defaultdict(list)
                 for v in value_list:
-                    # -*- coding: utf-8 -*-
-                    v_pair = v.split(u'\u2022')
-                    # No subitem
+                    v_pair = v.split(DELIMITER)
+                    # No child specified
                     if len(v_pair) == 1:
-                        # This will initialize empty list for item if not in item_dict yet
+                        # This will initialize empty list for item if not in 
+                        # item_dict yet
                         item_dict[v_pair[0]]
                     elif len(v_pair) == 2:
                         # put subproduct into list
@@ -63,25 +82,39 @@ class BaseBuilder(object):
 
                 # Go through item_dict to create filters
                 f_list = []
-                for item, subitems in item_dict.iteritems():
+                for item, child in item_dict.iteritems():
                     item_term = {"terms": {es_field_name: [item]}}
-                    # Item without any subitems
-                    if not subitems:
+                    # Item without any child specified
+                    if not child:
                         f_list.append(item_term)
                     else:
-                        subitem_term = {"terms": {es_subitem_field_name: subitems}}
-                        f_list.append({"and": {"filters": [item_term, subitem_term]}})
+                        child_term = {
+                            "terms": {
+                                self._get_es_name(self._get_child(field)): child
+                            }
+                        }
+                        f_list.append({"and": {"filters": [item_term, child_term]}})
 
                 return {"bool": {"should": f_list}}
 
-    def _create_and_append_bool_should_clauses(self, es_field_name, value_list, 
-        filter_list, with_subitems=False, es_subitem_field_name=None):
-        filter_clauses = self._create_bool_should_clauses(es_field_name, value_list, 
-            with_subitems, es_subitem_field_name)
+    # This creates a dictionary of all filter_clauses, where the keys are the field name
+    def _build_filter_clauses(self):
+        filter_clauses = {}
+        for item in self.params:
+            if item in self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL:
+                filter_clauses[item] = self._build_bool_should_clauses(item)
+        return filter_clauses
 
-        if filter_clauses:
-            filter_list.append(filter_clauses)
+    def _build_date_range_filter(self, date_min, date_max, es_field_name):
+        date_clause = {}
+        if date_min or date_max:
+            date_clause = {"range": {es_field_name: {}}}
+            if date_min:
+                date_clause["range"][es_field_name]["from"] = date_min
+            if date_max:
+                date_clause["range"][es_field_name]["to"] = date_max
 
+        return date_clause
 
 class SearchBuilder(BaseBuilder):
     def __init__(self):
@@ -149,76 +182,49 @@ class SearchBuilder(BaseBuilder):
 class PostFilterBuilder(BaseBuilder):
 
     def build(self):
+        filter_clauses = self._build_filter_clauses()
         post_filter = {"and": {"filters": []}}
 
         ## date_received
-        date_received_min = self.params.get("date_received_min")
-        date_received_max = self.params.get("date_received_max")
-        if date_received_min or date_received_max:
-            date_clause = {"range": {"date_received": {}}}
-            if date_received_min:
-                date_clause["range"]["date_received"]["from"] = date_received_min
-            if date_received_max:
-                date_clause["range"]["date_received"]["to"] = date_received_max
+        date_received = self._build_date_range_filter(
+            self.params.get("date_received_min"),
+            self.params.get("date_received_max"), 
+            "date_received")
 
-            post_filter["and"]["filters"].append(date_clause)
+        if date_received:
+            post_filter["and"]["filters"].append(date_received)
 
         ## company_received
-        company_received_min = self.params.get("company_received_min")
-        company_received_max = self.params.get("company_received_max")
-        if company_received_min or company_received_max:
-            company_clause = {"range": {"date_sent_to_company": {}}}
-            if company_received_min:
-                company_clause["range"]["date_sent_to_company"]["from"] = company_received_min
-            if company_received_max:
-                company_clause["range"]["date_sent_to_company"]["to"] = company_received_max
+        company_received = self._build_date_range_filter(
+            self.params.get("company_received_min"),
+            self.params.get("company_received_max"), 
+            "date_sent_to_company")
 
-            post_filter["and"]["filters"].append(company_clause)        
+        if company_received:
+            post_filter["and"]["filters"].append(company_received)
 
-        ## Create bool should clauses for fields in self._OPTIONAL_FILTERS
-        for field in self._OPTIONAL_FILTERS:
-            if field in self._OPTIONAL_FILTERS_CHILD_MAP: 
-                self._create_and_append_bool_should_clauses(self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(field, field), 
-                    self.params.get(field), post_filter["and"]["filters"], with_subitems=True, 
-                    es_subitem_field_name=self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(self._OPTIONAL_FILTERS_CHILD_MAP.get(field), 
-                        self._OPTIONAL_FILTERS_CHILD_MAP.get(field)))
-            else:
-                self._create_and_append_bool_should_clauses(self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(field, field), 
-                    self.params.get(field), post_filter["and"]["filters"])
-
-        for field in self._OPTIONAL_FILTERS_STRING_TO_BOOL:
-            if self.params.get(field):
-                self._create_and_append_bool_should_clauses(field, 
-                    [ 0 if cd.lower() == "no" else 1 for cd in self.params.get(field) ],
-                    post_filter["and"]["filters"])
+        ## Create filter clauses for all other filters
+        for item in self.params:
+            if item in self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL:
+                post_filter["and"]["filters"].append(filter_clauses[item])
 
         return post_filter
 
 class AggregationBuilder(BaseBuilder):
     
-    def build(self):
-    # All fields that need to have an aggregation entry
-        Field = namedtuple('Field', 'name size has_subfield')
-        fields = [
-            Field('has_narrative', 0, False),
-            Field('company', 0, False),
-            Field('product', 0, True),
-            Field('issue', 0, True),
-            Field('state', 0, False),
-            Field('zip_code', 0, False),
-            Field('timely', 0, False),
-            Field('company_response', 0, False),
-            Field('company_public_response', 0, False),
-            Field('consumer_disputed', 0, False),
-            Field('consumer_consent_provided', 0, False),
-            Field('tag', 0, False),
-            Field('submitted_via', 0, False)
-        ]
+    _AGG_FIELDS = ('has_narrative', 'company', 'product', 'issue', 'state', 
+        'zip_code', 'timely', 'company_response', 'company_public_response',
+        'consumer_disputed', 'consumer_consent_provided', 'tag', 'submitted_via')
 
+
+    def build(self):
+
+        # Build filter clauses for use later
+        filter_clauses = self._build_filter_clauses()
         aggs = {}
 
         # Creating aggregation object for each field above
-        for field in fields:
+        for field in self._AGG_FIELDS:
             field_aggs = {
                 "filter": {
                     "and": {
@@ -229,21 +235,22 @@ class AggregationBuilder(BaseBuilder):
                 }        
             }
 
-            es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(field.name, field.name)
-            es_subfield_name = None
-            if field.has_subfield:
-                es_subfield_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(self._OPTIONAL_FILTERS_CHILD_MAP.get(field.name))
+            es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(field, field)
+            es_child_name = None
+            if field in self._OPTIONAL_FILTERS_CHILD_MAP:
+                es_child_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
+                    self._OPTIONAL_FILTERS_CHILD_MAP.get(field))
                 field_aggs["aggs"] = {
-                    field.name: {
+                    field: {
                         "terms": {
                             "field": es_field_name,
-                            "size": field.size
+                            "size": 0
                         },
                         "aggs": {
-                            es_subfield_name: {
+                            es_child_name: {
                                 "terms": {
-                                    "field": es_subfield_name,
-                                    "size": field.size
+                                    "field": es_child_name,
+                                    "size": 0
                                 }
                             }
                         }
@@ -251,55 +258,34 @@ class AggregationBuilder(BaseBuilder):
                 }
             else:
                 field_aggs["aggs"] = {
-                    field.name: {
+                    field: {
                         "terms": {
                             "field": es_field_name,
-                            "size": field.size
+                            "size": 0
                         }
                     }
                 }
 
-            date_filter = {
-                "range": {
-                    "date_received": {
+            date_filter = self._build_date_range_filter(
+                self.params.get("date_received_min"), 
+                self.params.get("date_received_max"), "date_received")
 
-                    }
-                }
-            }
-            if "date_received_min" in self.params:
-                date_filter["range"]["date_received"]["from"] = self.params["date_received_min"]
-            if "date_received_max" in self.params:
-                date_filter["range"]["date_received"]["to"] = self.params["date_received_max"]
-            
-            field_aggs["filter"]["and"]["filters"].append(date_filter)
+            if date_filter:            
+                field_aggs["filter"]["and"]["filters"].append(date_filter)
 
-            company_date_filter = {
-                "range": {
-                    "date_sent_to_company": {
+            company_filter = self._build_date_range_filter(
+                self.params.get("company_received_min"), 
+                self.params.get("company_received_max"), "date_sent_to_company")
 
-                    }
-                }
-            }
-            if "company_received_min" in self.params:
-                company_date_filter["range"]["date_sent_to_company"]["from"] = self.params["company_received_min"]
-            if "company_received_max" in self.params:
-                company_date_filter["range"]["date_sent_to_company"]["to"] = self.params["company_received_max"]
-            
-            field_aggs["filter"]["and"]["filters"].append(company_date_filter)
-            
+            if company_filter:            
+                field_aggs["filter"]["and"]["filters"].append(company_filter)
+ 
             # Add filter clauses to aggregation entries (only those that are not the same as field name)
             for item in self.params:
-                if item in self._OPTIONAL_FILTERS and item != field.name:
-                    clauses = self._create_and_append_bool_should_clauses(self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(item, item), 
-                        self.params[item], field_aggs["filter"]["and"]["filters"], 
-                        with_subitems=item in self._OPTIONAL_FILTERS_CHILD_MAP, 
-                        es_subitem_field_name=self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(self._OPTIONAL_FILTERS_CHILD_MAP.get(item)))
-                elif item in self._OPTIONAL_FILTERS_STRING_TO_BOOL and item != field.name:
-                    clauses = self._create_and_append_bool_should_clauses(self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(item, item), 
-                        [ 0 if cd.lower() == "no" else 1 for cd in self.params[item] ],
-                        field_aggs["filter"]["and"]["filters"])
+                if item != field and item in self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL:
+                    field_aggs["filter"]["and"]["filters"].append(filter_clauses[item])
 
-            aggs[field.name] = field_aggs
+            aggs[field] = field_aggs
 
         return aggs        
 

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -151,15 +151,29 @@ class PostFilterBuilder(BaseBuilder):
     def build(self):
         post_filter = {"and": {"filters": []}}
 
-        ## date
-        if self.params.get("min_date") or self.params.get("max_date"):
+        ## date_received
+        date_received_min = self.params.get("date_received_min")
+        date_received_max = self.params.get("date_received_max")
+        if date_received_min or date_received_max:
             date_clause = {"range": {"date_received": {}}}
-            if self.params.get("min_date"):
-                date_clause["range"]["date_received"]["from"] = self.params.get("min_date")
-            if self.params.get("max_date"):
-                date_clause["range"]["date_received"]["to"] = self.params.get("max_date")
+            if date_received_min:
+                date_clause["range"]["date_received"]["from"] = date_received_min
+            if date_received_max:
+                date_clause["range"]["date_received"]["to"] = date_received_max
 
             post_filter["and"]["filters"].append(date_clause)
+
+        ## company_received
+        company_received_min = self.params.get("company_received_min")
+        company_received_max = self.params.get("company_received_max")
+        if company_received_min or company_received_max:
+            company_clause = {"range": {"date_sent_to_company": {}}}
+            if company_received_min:
+                company_clause["range"]["date_sent_to_company"]["from"] = company_received_min
+            if company_received_max:
+                company_clause["range"]["date_sent_to_company"]["to"] = company_received_max
+
+            post_filter["and"]["filters"].append(company_clause)        
 
         ## Create bool should clauses for fields in self._OPTIONAL_FILTERS
         for field in self._OPTIONAL_FILTERS:
@@ -252,12 +266,26 @@ class AggregationBuilder(BaseBuilder):
                     }
                 }
             }
-            if "min_date" in self.params:
-                date_filter["range"]["date_received"]["from"] = self.params["min_date"]
-            if "max_date" in self.params:
-                date_filter["range"]["date_received"]["to"] = self.params["max_date"]
+            if "date_received_min" in self.params:
+                date_filter["range"]["date_received"]["from"] = self.params["date_received_min"]
+            if "date_received_max" in self.params:
+                date_filter["range"]["date_received"]["to"] = self.params["date_received_max"]
             
             field_aggs["filter"]["and"]["filters"].append(date_filter)
+
+            company_date_filter = {
+                "range": {
+                    "date_sent_to_company": {
+
+                    }
+                }
+            }
+            if "company_received_min" in self.params:
+                company_date_filter["range"]["date_sent_to_company"]["from"] = self.params["company_received_min"]
+            if "company_received_max" in self.params:
+                company_date_filter["range"]["date_sent_to_company"]["to"] = self.params["company_received_max"]
+            
+            field_aggs["filter"]["and"]["filters"].append(company_date_filter)
             
             # Add filter clauses to aggregation entries (only those that are not the same as field name)
             for item in self.params:

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -38,6 +38,7 @@ def get_meta():
         "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
         "total_record_count": count_res["count"]
     }
+    
 # List of possible arguments:
 # - format: format to be returned: "json", "csv", "xls", or "xlsx"
 # - field: field you want to search in: "complaint_what_happened", "company_public_response", "_all"
@@ -45,8 +46,10 @@ def get_meta():
 # - frm: from which index to start returning
 # - sort: sort by: "relevance_desc", "relevance_asc", "created_date_desc", "created_date_asc"
 # - search_term: the term to be searched
-# - min_date: return only date including and later than this date i.e. 2017-03-02
-# - max_date: return only date before this date, i.e. 2017-04-12 
+# - date_received_min: return only date received including and later than this date i.e. 2017-03-02
+# - date_received_max: return only date received before this date, i.e. 2017-04-12 
+# - company_received_min: return only date company received including and later than this date i.e. 2017-03-02
+# - company_received_max: return only date company received before this date, i.e. 2017-04-12 
 # - company: filters a list of companies you want ["Bank 1", "Bank 2"]
 # - product: filters a list of product you want if a subproduct is needed to filter, separated by a bullet (u'\u2022), i.e. [u"Mortgage\u2022FHA Mortgage", "Payday Loan"]
 # - issue: filters a list of issue you want if a subissue is needed to filter, separated by a bullet (u'\u2022), i.e. See Product above

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -49,8 +49,10 @@ class SearchInputSerializer(serializers.Serializer):
     frm = serializers.IntegerField(min_value=0, max_value=100000, default=PARAMS['frm'])
     sort = serializers.ChoiceField(SORT_CHOICES, default=PARAMS['sort'])
     search_term = serializers.CharField(max_length=200, required=False)
-    min_date = serializers.DateField(required=False)
-    max_date = serializers.DateField(required=False)
+    date_received_min = serializers.DateField(required=False)
+    date_received_max = serializers.DateField(required=False)
+    company_received_min = serializers.DateField(required=False)
+    company_received_max = serializers.DateField(required=False)
     company = serializers.ListField(
         child=serializers.CharField(max_length=200), required=False)
     product = serializers.ListField(

--- a/complaint_search/tests/expected_results/search_no_param__valid.json
+++ b/complaint_search/tests/expected_results/search_no_param__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_no_param__valid.json
+++ b/complaint_search/tests/expected_results/search_no_param__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_company__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company__valid.json
@@ -42,6 +42,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -70,6 +75,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -90,6 +100,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -129,6 +144,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -166,6 +186,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -193,6 +218,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -224,6 +254,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -251,6 +286,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -282,6 +322,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -309,6 +354,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -340,6 +390,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -369,6 +424,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -396,6 +456,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_company__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company__valid.json
@@ -37,16 +37,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -70,18 +60,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -97,16 +76,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -139,16 +108,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -181,16 +140,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -215,16 +164,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -249,16 +188,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -283,16 +212,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -317,16 +236,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -351,16 +260,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -385,16 +284,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -419,16 +308,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -453,16 +332,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +195,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -289,16 +219,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -322,18 +242,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -349,16 +258,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -383,16 +282,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -417,16 +306,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -451,16 +330,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
@@ -40,6 +40,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,6 +74,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -96,6 +106,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -135,6 +150,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,6 +192,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -199,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -230,6 +260,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -257,6 +292,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -287,6 +327,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -307,6 +352,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -338,6 +388,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -367,6 +422,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -394,6 +454,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_company_received_max__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_received_max__valid.json
@@ -38,11 +38,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -66,11 +61,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -92,11 +82,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -130,11 +115,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -166,11 +146,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -192,11 +167,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -222,11 +192,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -248,11 +213,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -278,11 +238,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -304,11 +259,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -334,11 +284,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -362,11 +307,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "to": "2017-04-14"
                                 }
@@ -388,11 +328,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {

--- a/complaint_search/tests/expected_results/search_with_company_received_max__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_received_max__valid.json
@@ -20,14 +20,15 @@
     "sort": [{"_score": {"order": "desc"}}],
     "post_filter": {
         "and": {
-            "filters": [{ 
-                "bool": {
-                    "should": [
-                        {"terms": {"consumer_disputed.raw": ["No"]}},
-                        {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                    ]
+            "filters": [
+                {
+                    "range": {
+                        "date_sent_to_company": {
+                            "to": "2017-04-14"
+                        }
+                    }
                 }
-            }]
+            ]
         }
     },
     "aggs": {
@@ -42,15 +43,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -76,15 +71,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -110,15 +99,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -152,15 +135,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -194,15 +171,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -228,15 +199,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -262,15 +227,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -296,15 +255,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -330,15 +283,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -364,7 +311,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -390,15 +339,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -424,15 +367,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]
@@ -458,15 +395,9 @@
                         },
                         {
                             "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
+                                "date_sent_to_company": {
+                                    "to": "2017-04-14"
+                                }
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_company_received_min__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_received_min__valid.json
@@ -38,11 +38,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -66,11 +61,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -92,11 +82,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -130,11 +115,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -166,11 +146,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -192,11 +167,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -222,11 +192,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -248,11 +213,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -278,11 +238,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -304,11 +259,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {
@@ -334,11 +284,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -362,11 +307,6 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
                                 "date_sent_to_company": {
                                     "from": "2014-04-14"
                                 }
@@ -388,11 +328,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
                         {
                             "range": {
                                 "date_sent_to_company": {

--- a/complaint_search/tests/expected_results/search_with_company_received_min__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_received_min__valid.json
@@ -23,8 +23,8 @@
             "filters": [
                 {
                     "range": {
-                        "date_received": {
-                            "to": "2017-04-14"
+                        "date_sent_to_company": {
+                            "from": "2014-04-14"
                         }
                     }
                 }
@@ -38,8 +38,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -61,8 +66,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -84,8 +94,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -115,8 +130,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -146,8 +166,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -169,8 +194,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -192,8 +222,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -215,8 +250,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -238,8 +278,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -261,8 +306,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -284,8 +334,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -307,8 +362,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }
@@ -330,8 +390,13 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {
-                                    "to": "2017-04-14"
+                                "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {
+                                    "from": "2014-04-14"
                                 }
                             }
                         }

--- a/complaint_search/tests/expected_results/search_with_company_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_response__valid.json
@@ -40,6 +40,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,6 +74,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -96,6 +106,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -135,6 +150,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,6 +192,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -199,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -230,6 +260,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -258,6 +293,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -278,6 +318,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -309,6 +354,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -336,6 +386,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -367,6 +422,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -394,6 +454,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_company_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_response__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +195,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -288,18 +218,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -314,18 +233,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
-                        { 
+                    "filters": [                        { 
                             "bool": {
                                 "should": [
                                     {"terms": {"company_response": ["Closed"]}},
@@ -349,16 +257,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -383,16 +281,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -417,16 +305,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -451,16 +329,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
+++ b/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
@@ -40,6 +40,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,6 +74,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -96,6 +106,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -135,6 +150,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,6 +192,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -199,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -230,6 +260,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -257,6 +292,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -288,6 +328,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -315,6 +360,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -345,6 +395,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -365,6 +420,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -394,6 +454,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
+++ b/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +195,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -289,16 +219,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -323,16 +243,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -357,16 +267,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -390,18 +290,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -417,16 +306,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -451,16 +330,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_consumer_disputed__valid.json
+++ b/complaint_search/tests/expected_results/search_with_consumer_disputed__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +195,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -289,16 +219,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -323,16 +243,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -356,18 +266,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -383,16 +282,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -417,16 +306,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -451,16 +330,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_date_received_max__valid.json
+++ b/complaint_search/tests/expected_results/search_with_date_received_max__valid.json
@@ -24,7 +24,7 @@
                 {
                     "range": {
                         "date_received": {
-                            "from": "2014-04-14"
+                            "to": "2017-04-14"
                         }
                     }
                 }
@@ -39,8 +39,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -62,8 +67,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -85,8 +95,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -116,8 +131,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -147,8 +167,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,8 +195,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -193,8 +223,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -216,8 +251,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -239,8 +279,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -262,8 +307,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -285,8 +335,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -308,8 +363,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -331,8 +391,13 @@
                         {
                             "range": {
                                 "date_received": {
-                                    "from": "2014-04-14"
+                                    "to": "2017-04-14"
                                 }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_date_received_max__valid.json
+++ b/complaint_search/tests/expected_results/search_with_date_received_max__valid.json
@@ -42,11 +42,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -70,11 +65,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -97,11 +87,6 @@
                                 "date_received": {
                                     "to": "2017-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -134,11 +119,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -170,11 +150,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -197,11 +172,6 @@
                                 "date_received": {
                                     "to": "2017-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -226,11 +196,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -253,11 +218,6 @@
                                 "date_received": {
                                     "to": "2017-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -282,11 +242,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -309,11 +264,6 @@
                                 "date_received": {
                                     "to": "2017-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -338,11 +288,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -366,11 +311,6 @@
                                     "to": "2017-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -393,11 +333,6 @@
                                 "date_received": {
                                     "to": "2017-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_date_received_min__valid.json
+++ b/complaint_search/tests/expected_results/search_with_date_received_min__valid.json
@@ -20,14 +20,15 @@
     "sort": [{"_score": {"order": "desc"}}],
     "post_filter": {
         "and": {
-            "filters": [{ 
-                "bool": {
-                    "should": [
-                        {"terms": {"consumer_disputed.raw": ["No"]}},
-                        {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                    ]
+            "filters": [
+                {
+                    "range": {
+                        "date_received": {
+                            "from": "2014-04-14"
+                        }
+                    }
                 }
-            }]
+            ]
         }
     },
     "aggs": {
@@ -37,20 +38,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -71,20 +66,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -105,20 +94,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -147,20 +130,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -189,20 +166,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -223,20 +194,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -257,20 +222,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -291,20 +250,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -325,20 +278,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -359,7 +306,9 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
@@ -385,20 +334,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -419,20 +362,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]
@@ -453,20 +390,14 @@
                     "filters": [
                         {
                             "range": {
-                                "date_received": {}
+                                "date_received": {
+                                    "from": "2014-04-14"
+                                }
                             }
                         },
                         {
                             "range": {
                                 "date_sent_to_company": {}
-                            }
-                        },
-                        { 
-                            "bool": {
-                                "should": [
-                                    {"terms": {"consumer_disputed.raw": ["No"]}},
-                                    {"terms": {"consumer_disputed.raw": ["Yes"]}}
-                                ]
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_date_received_min__valid.json
+++ b/complaint_search/tests/expected_results/search_with_date_received_min__valid.json
@@ -42,11 +42,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -70,11 +65,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -97,11 +87,6 @@
                                 "date_received": {
                                     "from": "2014-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -134,11 +119,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -170,11 +150,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -197,11 +172,6 @@
                                 "date_received": {
                                     "from": "2014-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -226,11 +196,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -253,11 +218,6 @@
                                 "date_received": {
                                     "from": "2014-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -282,11 +242,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -309,11 +264,6 @@
                                 "date_received": {
                                     "from": "2014-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -338,11 +288,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -366,11 +311,6 @@
                                     "from": "2014-04-14"
                                 }
                             }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
                         }
                     ]
                 }
@@ -393,11 +333,6 @@
                                 "date_received": {
                                     "from": "2014-04-14"
                                 }
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_field__valid.json
+++ b/complaint_search/tests/expected_results/search_with_field__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_field__valid.json
+++ b/complaint_search/tests/expected_results/search_with_field__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_frm__valid.json
+++ b/complaint_search/tests/expected_results/search_with_frm__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_frm__valid.json
+++ b/complaint_search/tests/expected_results/search_with_frm__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
+++ b/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
@@ -34,18 +34,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -61,16 +50,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -95,16 +74,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -137,16 +106,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -179,16 +138,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -213,16 +162,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -247,16 +186,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -281,16 +210,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -315,16 +234,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -349,16 +258,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -383,16 +282,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -417,16 +306,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -451,16 +330,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
+++ b/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
@@ -39,6 +39,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -59,6 +64,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -88,6 +98,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -127,6 +142,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -164,6 +184,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -191,6 +216,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -222,6 +252,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -249,6 +284,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -280,6 +320,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -307,6 +352,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -338,6 +388,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -367,6 +422,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -394,6 +454,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_issue__valid.json
+++ b/complaint_search/tests/expected_results/search_with_issue__valid.json
@@ -47,6 +47,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -83,6 +88,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -117,6 +127,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -162,6 +177,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +210,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -228,6 +253,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -262,6 +292,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -300,6 +335,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -334,6 +374,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -372,6 +417,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -406,6 +456,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -444,6 +499,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -478,6 +538,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_issue__valid.json
+++ b/complaint_search/tests/expected_results/search_with_issue__valid.json
@@ -42,16 +42,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -83,16 +73,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -124,16 +104,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,18 +142,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -207,16 +166,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -248,16 +197,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -289,16 +228,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -330,16 +259,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -371,16 +290,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -412,16 +321,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -453,16 +352,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -494,16 +383,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -535,16 +414,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_product__valid.json
+++ b/complaint_search/tests/expected_results/search_with_product__valid.json
@@ -50,6 +50,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -85,6 +90,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -123,6 +133,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -151,6 +166,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -198,6 +218,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -233,6 +258,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -272,6 +302,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -307,6 +342,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -346,6 +386,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -381,6 +426,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -420,6 +470,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -457,6 +512,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -492,6 +552,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_product__valid.json
+++ b/complaint_search/tests/expected_results/search_with_product__valid.json
@@ -45,16 +45,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -87,16 +77,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -128,18 +108,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -163,16 +132,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -213,16 +172,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +204,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -297,16 +236,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -339,16 +268,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -381,16 +300,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -423,16 +332,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -465,16 +364,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -507,16 +396,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -549,16 +428,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
@@ -22,18 +22,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -48,18 +37,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -74,18 +52,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -108,18 +75,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -142,18 +98,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -168,18 +113,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -194,18 +128,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -220,18 +143,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -246,18 +158,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -272,18 +173,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -298,18 +188,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -324,18 +203,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -350,18 +218,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
@@ -27,6 +27,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -48,6 +53,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -68,6 +78,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -98,6 +113,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -127,6 +147,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -147,6 +172,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -169,6 +199,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -189,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -211,6 +251,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -231,6 +276,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -253,6 +303,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -274,6 +329,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -294,6 +354,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_size__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size__valid.json
@@ -28,6 +28,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -49,6 +54,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -69,6 +79,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -99,6 +114,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -128,6 +148,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -148,6 +173,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -170,6 +200,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -190,6 +225,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -212,6 +252,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -232,6 +277,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -254,6 +304,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -275,6 +330,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -295,6 +355,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_size__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size__valid.json
@@ -23,18 +23,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -49,18 +38,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -75,18 +53,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -109,18 +76,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -143,18 +99,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -169,18 +114,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -195,18 +129,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -221,18 +144,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -247,18 +159,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -273,18 +174,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -299,18 +189,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -325,18 +204,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -351,18 +219,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_sort__valid.json
+++ b/complaint_search/tests/expected_results/search_with_sort__valid.json
@@ -22,18 +22,7 @@
         "has_narrative": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -48,18 +37,7 @@
         "company": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -74,18 +52,7 @@
         "product": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -108,18 +75,7 @@
         "issue": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -142,18 +98,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -168,18 +113,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -194,18 +128,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -220,18 +143,7 @@
         "company_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -246,18 +158,7 @@
         "company_public_response": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -272,18 +173,7 @@
         "consumer_disputed": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -298,18 +188,7 @@
         "consumer_consent_provided": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -324,18 +203,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -350,18 +218,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_sort__valid.json
+++ b/complaint_search/tests/expected_results/search_with_sort__valid.json
@@ -27,6 +27,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -48,6 +53,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -68,6 +78,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -98,6 +113,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -127,6 +147,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -147,6 +172,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -169,6 +199,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -189,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -211,6 +251,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -231,6 +276,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]
@@ -253,6 +303,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -274,6 +329,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -294,6 +354,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_state__valid.json
+++ b/complaint_search/tests/expected_results/search_with_state__valid.json
@@ -41,6 +41,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -71,6 +76,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -99,6 +109,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -139,6 +154,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -176,6 +196,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -196,6 +221,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -228,6 +258,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -256,6 +291,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -288,6 +328,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -316,6 +361,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -348,6 +398,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -378,6 +433,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -406,6 +466,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_state__valid.json
+++ b/complaint_search/tests/expected_results/search_with_state__valid.json
@@ -36,16 +36,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -71,16 +61,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -106,16 +86,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -149,16 +119,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -191,18 +151,7 @@
         "state": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -218,16 +167,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -253,16 +192,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -288,16 +217,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -323,16 +242,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -358,16 +267,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -393,16 +292,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -428,16 +317,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -463,16 +342,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
+++ b/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +195,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -289,16 +219,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -323,16 +243,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -357,16 +267,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -391,16 +291,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -425,16 +315,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -458,18 +338,7 @@
         "submitted_via": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {

--- a/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
+++ b/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
@@ -40,6 +40,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,6 +74,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -96,6 +106,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -135,6 +150,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,6 +192,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -199,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -230,6 +260,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -257,6 +292,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -288,6 +328,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -315,6 +360,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -346,6 +396,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -375,6 +430,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -402,6 +462,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         }
                     ]

--- a/complaint_search/tests/expected_results/search_with_tag__valid.json
+++ b/complaint_search/tests/expected_results/search_with_tag__valid.json
@@ -40,6 +40,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,6 +74,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -96,6 +106,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -135,6 +150,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,6 +192,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -199,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -230,6 +260,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -257,6 +292,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -288,6 +328,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -315,6 +360,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -346,6 +396,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -374,6 +429,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -394,6 +454,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_tag__valid.json
+++ b/complaint_search/tests/expected_results/search_with_tag__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -255,16 +195,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -289,16 +219,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -323,16 +243,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -357,16 +267,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -391,16 +291,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -424,18 +314,7 @@
         "tag": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -451,16 +330,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_timely__valid.json
+++ b/complaint_search/tests/expected_results/search_with_timely__valid.json
@@ -40,6 +40,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,6 +74,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -96,6 +106,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -135,6 +150,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -172,6 +192,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -199,6 +224,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -229,6 +259,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -249,6 +284,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -280,6 +320,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -307,6 +352,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -338,6 +388,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -367,6 +422,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -394,6 +454,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/expected_results/search_with_timely__valid.json
+++ b/complaint_search/tests/expected_results/search_with_timely__valid.json
@@ -35,16 +35,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -69,16 +59,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -103,16 +83,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -145,16 +115,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -187,16 +147,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -221,16 +171,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -254,18 +194,7 @@
         "timely": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -281,16 +210,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -315,16 +234,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -349,16 +258,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -383,16 +282,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -417,16 +306,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -451,16 +330,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_zip_code__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code__valid.json
@@ -36,16 +36,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -71,16 +61,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -106,16 +86,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -149,16 +119,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -192,16 +152,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -226,18 +176,7 @@
         "zip_code": {
             "filter": {
                 "and": {
-                    "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        }
-                    ]
+                    "filters": []
                 }
             },
             "aggs": {
@@ -253,16 +192,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -288,16 +217,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -323,16 +242,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -358,16 +267,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -393,16 +292,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -428,16 +317,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [
@@ -463,16 +342,6 @@
             "filter": {
                 "and": {
                     "filters": [
-                        {
-                            "range": {
-                                "date_received": {}
-                            }
-                        },
-                        {
-                            "range": {
-                                "date_sent_to_company": {}
-                            }
-                        },
                         { 
                             "bool": {
                                 "should": [

--- a/complaint_search/tests/expected_results/search_with_zip_code__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code__valid.json
@@ -41,6 +41,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -71,6 +76,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -99,6 +109,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -139,6 +154,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -177,6 +197,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -206,6 +231,11 @@
                             "range": {
                                 "date_received": {}
                             }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
                         }
                     ]
                 }
@@ -226,6 +256,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -258,6 +293,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -286,6 +326,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -318,6 +363,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -346,6 +396,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 
@@ -378,6 +433,11 @@
                                 "date_received": {}
                             }
                         },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
+                            }
+                        },
                         { 
                             "bool": {
                                 "should": [
@@ -406,6 +466,11 @@
                         {
                             "range": {
                                 "date_received": {}
+                            }
+                        },
+                        {
+                            "range": {
+                                "date_sent_to_company": {}
                             }
                         },
                         { 

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -102,6 +102,10 @@ class EsInterfaceTest(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search no param"
+            diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -367,16 +371,20 @@ class EsInterfaceTest(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_min_date__valid(self, mock_scroll, mock_count, mock_search):
+    def test_search_with_date_received_min__valid(self, mock_scroll, mock_count, mock_search):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        body = self.load("search_with_min_date__valid")
-        res = search(min_date="2014-04-14")
+        body = self.load("search_with_date_received_min__valid")
+        res = search(date_received_min="2014-04-14")
         self.assertEqual(2, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search with date_received_min"
+            diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -386,16 +394,67 @@ class EsInterfaceTest(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_max_date__valid(self, mock_scroll, mock_count, mock_search):
+    def test_search_with_date_received_max__valid(self, mock_scroll, mock_count, mock_search):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        body = self.load("search_with_max_date__valid")
-        res = search(max_date="2017-04-14")
+        body = self.load("search_with_date_received_max__valid")
+        res = search(date_received_max="2017-04-14")
         self.assertEqual(2, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search with date_received_max"
+            diff.print_full()
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch.object(Elasticsearch, 'search')
+    @mock.patch.object(Elasticsearch, 'count')
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_company_received_min__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        body = self.load("search_with_company_received_min__valid")
+        res = search(company_received_min="2014-04-14")
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search with company_received_min"
+            diff.print_full()
+        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
+        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch.object(Elasticsearch, 'search')
+    @mock.patch.object(Elasticsearch, 'count')
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_company_received_max__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        body = self.load("search_with_company_received_max__valid")
+        res = search(company_received_max="2017-04-14")
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search with company_received_max"
+            diff.print_full()
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -241,47 +241,91 @@ class SearchTests(APITestCase):
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
-    def test_search_with_min_date__valid(self, mock_essearch):
+    def test_search_with_date_received_min__valid(self, mock_essearch):
         url = reverse('complaint_search:search')
-        params = {"min_date": "2017-04-11"}
+        params = {"date_received_min": "2017-04-11"}
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         mock_essearch.assert_called_once_with(**self.buildDefaultParams({
-            "min_date": date(2017, 4, 11)}))
+            "date_received_min": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
-    def test_search_with_min_date__invalid_format(self, mock_essearch):
+    def test_search_with_date_received_min__invalid_format(self, mock_essearch):
         url = reverse('complaint_search:search')
-        params = {"min_date": "not_a_date"}
+        params = {"date_received_min": "not_a_date"}
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
-        self.assertDictEqual({"min_date": ["Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]."]}, 
+        self.assertDictEqual({"date_received_min": ["Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]."]}, 
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')
-    def test_search_with_max_date__valid(self, mock_essearch):
+    def test_search_with_date_received_max__valid(self, mock_essearch):
         url = reverse('complaint_search:search')
-        params = {"max_date": "2017-04-11"}
+        params = {"date_received_max": "2017-04-11"}
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         mock_essearch.assert_called_once_with(**self.buildDefaultParams({
-            "max_date": date(2017, 4, 11)}))
+            "date_received_max": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
-    def test_search_with_max_date__invalid_format(self, mock_essearch):
+    def test_search_with_date_received_max__invalid_format(self, mock_essearch):
         url = reverse('complaint_search:search')
-        params = {"max_date": "not_a_date"}
+        params = {"date_received_max": "not_a_date"}
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
-        self.assertDictEqual({"max_date": ["Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]."]}, 
+        self.assertDictEqual({"date_received_max": ["Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]."]}, 
+            response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_company_received_min__valid(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = {"company_received_min": "2017-04-11"}
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+            "company_received_min": date(2017, 4, 11)}))
+        self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_company_received_min__invalid_format(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = {"company_received_min": "not_a_date"}
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        mock_essearch.assert_not_called()
+        self.assertDictEqual({"company_received_min": ["Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]."]}, 
+            response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_company_received_max__valid(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = {"company_received_max": "2017-04-11"}
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+            "company_received_max": date(2017, 4, 11)}))
+        self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_company_received_max__invalid_format(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        params = {"company_received_max": "not_a_date"}
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url, params)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        mock_essearch.assert_not_called()
+        self.assertDictEqual({"company_received_max": ["Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]]."]}, 
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -32,8 +32,9 @@ def search(request):
     # When you add a query parameter, make sure you add it to one of the 
     # constant tuples below so it will be parse correctly
 
-    QPARAMS_VARS = ('fmt', 'field', 'size', 'frm', 'sort', 
-        'search_term', 'min_date', 'max_date', 'no_aggs')
+    QPARAMS_VARS = ('fmt', 'field', 'size', 'frm', 'sort', 'search_term', 
+        'date_received_min', 'date_received_max', 'company_received_min',
+        'company_received_max', 'no_aggs')
 
     QPARAMS_LISTS = ('company', 'product', 'issue', 'state', 
         'zip_code', 'timely', 'consumer_disputed', 'company_response',


### PR DESCRIPTION
Added another date filters for `date_sent_to_company`, this means we also need to rework the names for the current `min_date` and `max_date` query parameters to make them more specific.

## Additions:
- Added 2 date query parameters: `company_received_min`, and `company_received_max` to specified the "from date" and "to date" for `date_sent_to_company`

## Changes:
- Changed `min_date` and `max_date` to `date_received_min` and `date_received_max` respectively
- Updated tests
- Refactored code