### PR TITLE
Highlight text in fields that were searched

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -101,8 +101,9 @@ class SearchBuilder(BaseBuilder):
                 }
             },
             "highlight": {
+                "require_field_match": False,
                 "fields": {
-                    self.params.get("field"): {}
+                    "complaint_what_happened": {}
                 },
                 "number_of_fragments": 1,
                 "fragment_size": 500

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -87,6 +87,40 @@ class SearchBuilder(BaseBuilder):
     def __init__(self):
         self.params = copy.deepcopy(PARAMS)
 
+    def _build_highlight(self):
+        highlight = {
+            "require_field_match": False,
+            "number_of_fragments": 1,
+            "fragment_size": 500
+        }
+        if self.params.get("field") == "_all":
+            highlight["fields"] = {
+                "sub_product": {},
+                "date_sent_to_company": {},
+                "complaint_id": {},
+                "consumer_consent_provided": {},
+                "date_received": {},
+                "state": {},
+                "issue": {},
+                "company_response": {},
+                "zip_code": {},
+                "timely": {},
+                "product": {},
+                "complaint_what_happened": {},
+                "company": {},
+                "sub_issue": {},
+                "tags": {},
+                "company_public_response": {},
+                "consumer_disputed": {},
+                "has_narrative": {},
+                "submitted_via": {}
+            }
+
+        else:
+            highlight["fields"] = { self.params.get("field"): {}}
+
+        return highlight
+
     def build(self):
         search = {
             "from": self.params.get("frm"), 
@@ -99,16 +133,11 @@ class SearchBuilder(BaseBuilder):
                     ],
                     "default_operator": "AND"
                 }
-            },
-            "highlight": {
-                "require_field_match": False,
-                "fields": {
-                    "complaint_what_happened": {}
-                },
-                "number_of_fragments": 1,
-                "fragment_size": 500
             }
         }
+
+        # Highlight
+        search["highlight"] = self._build_highlight()
 
         # sort
         sort_field, sort_order = self.params.get("sort").rsplit("_", 1)

--- a/complaint_search/tests/expected_results/search_no_param__valid.json
+++ b/complaint_search/tests/expected_results/search_no_param__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_company__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_company_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_response__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
+++ b/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_consumer_disputed__valid.json
+++ b/complaint_search/tests/expected_results/search_with_consumer_disputed__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_field__valid.json
+++ b/complaint_search/tests/expected_results/search_with_field__valid.json
@@ -11,8 +11,9 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
-            "test_field": {}
+            "complaint_what_happened": {}
         },
         "number_of_fragments": 1,
         "fragment_size": 500

--- a/complaint_search/tests/expected_results/search_with_field_all__valid.json
+++ b/complaint_search/tests/expected_results/search_with_field_all__valid.json
@@ -5,7 +5,7 @@
         "query_string": {
             "query": "*",
             "fields": [
-                "test_field"
+                "_all"
             ],
             "default_operator": "AND"
         }
@@ -13,7 +13,25 @@
     "highlight": {
         "require_field_match": false,
         "fields": {
-            "test_field": {}
+            "sub_product": {},
+            "date_sent_to_company": {},
+            "complaint_id": {},
+            "consumer_consent_provided": {},
+            "date_received": {},
+            "state": {},
+            "issue": {},
+            "company_response": {},
+            "zip_code": {},
+            "timely": {},
+            "product": {},
+            "complaint_what_happened": {},
+            "company": {},
+            "sub_issue": {},
+            "tags": {},
+            "company_public_response": {},
+            "consumer_disputed": {},
+            "has_narrative": {},
+            "submitted_via": {}
         },
         "number_of_fragments": 1,
         "fragment_size": 500

--- a/complaint_search/tests/expected_results/search_with_format_nonjson__valid.json
+++ b/complaint_search/tests/expected_results/search_with_format_nonjson__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_frm__valid.json
+++ b/complaint_search/tests/expected_results/search_with_frm__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
+++ b/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_issue__valid.json
+++ b/complaint_search/tests/expected_results/search_with_issue__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_max_date__valid.json
+++ b/complaint_search/tests/expected_results/search_with_max_date__valid.json
@@ -11,13 +11,13 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },
         "number_of_fragments": 1,
         "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
+    },    "sort": [{"_score": {"order": "desc"}}],
     "post_filter": {
         "and": {
             "filters": [

--- a/complaint_search/tests/expected_results/search_with_min_date__valid.json
+++ b/complaint_search/tests/expected_results/search_with_min_date__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_product__valid.json
+++ b/complaint_search/tests/expected_results/search_with_product__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
@@ -10,6 +10,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_size__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_sort__valid.json
+++ b/complaint_search/tests/expected_results/search_with_sort__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_state__valid.json
+++ b/complaint_search/tests/expected_results/search_with_state__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
+++ b/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_tag__valid.json
+++ b/complaint_search/tests/expected_results/search_with_tag__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_timely__valid.json
+++ b/complaint_search/tests/expected_results/search_with_timely__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/expected_results/search_with_zip_code__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code__valid.json
@@ -11,6 +11,7 @@
         }
     },
     "highlight": {
+        "require_field_match": false,
         "fields": {
             "complaint_what_happened": {}
         },

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -158,7 +158,37 @@ class EsInterfaceTest(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search with field"
+            diff.print_full()
+        self.assertIsNone(deep.diff(act_body, body))
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch.object(Elasticsearch, 'search')
+    @mock.patch.object(Elasticsearch, 'count')
+    @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_field_all__valid(self, mock_scroll, mock_count, mock_search):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
+        body = self.load("search_with_field_all__valid")
+        res = search(field="_all")
+        self.assertEqual(2, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
+        act_body = mock_search.call_args_list[0][1]['body']
+        diff = deep.diff(act_body, body)
+        if diff:
+            print "search with field _all"
+            diff.print_full()
+
+        self.assertIsNone(deep.diff(act_body, body))
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
         self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
@@ -517,6 +547,7 @@ class EsInterfaceTest(TestCase):
         if diff:
             print "zip_code"
             diff.print_full()
+
         self.assertIsNone(deep.diff(act_body, body))
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')


### PR DESCRIPTION
Forcing highlighting for `complaint_what_happened` field no matter what field we are searching on.

## Additions:
- Added force highlighting on field that doesn't match search field

## Changes:
- If field = `_all`, highlight text from all possible fields, else the field that was specified