### PR TITLE
5 Business Day Notification Metdata

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,3 +20,4 @@ omit =
 exclude_lines = 
     pragma: no cover
     if __name__ == .__main__.:
+    datetime.now()

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -34,7 +34,7 @@ def _get_es():
 def _get_now():
     return datetime.now()
 
-def _four_business_days_ago():
+def _min_valid_time():
     # show notification starting fifth business day data has not been updated
     # M-Th, data needs to have been updated 6 days ago; F-S, preceding Monday
     now = _get_now()
@@ -46,7 +46,7 @@ def _four_business_days_ago():
     return (now - timedelta(delta)).strftime("%Y-%m-%d")
 
 def _is_data_stale(last_updated_time):
-    if (last_updated_time < _four_business_days_ago()):
+    if (last_updated_time < _min_valid_time()):
         return True
 
     return False

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -1,5 +1,15 @@
 from django.test import TestCase
-from complaint_search.es_interface import _ES_URL, _COMPLAINT_ES_INDEX, _COMPLAINT_DOC_TYPE, _ES_USER, _ES_PASSWORD, get_meta, search, suggest, document
+from complaint_search.es_interface import (
+    _ES_URL, 
+    _COMPLAINT_ES_INDEX, 
+    _COMPLAINT_DOC_TYPE, 
+    _ES_USER, 
+    _ES_PASSWORD, 
+    _get_meta, 
+    search, 
+    suggest, 
+    document
+)
 from elasticsearch import Elasticsearch
 import requests
 import os
@@ -83,7 +93,7 @@ class EsInterfaceTest(TestCase):
         mock_search.return_value = self.MOCK_SEARCH_SIDE_EFFECT[1]
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
 
-        res = get_meta()
+        res = _get_meta()
         self.assertDictEqual(self.MOCK_SEARCH_RESULT["_meta"], res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -47,7 +47,6 @@ def search(request):
     #     for param in request.query_params if param in QPARAMS_VARS + QPARAMS_LISTS}
 
     data = {}
-
     # Add format to data (only checking if it is csv, xls, xlsx, then specific them)
     format = request.accepted_renderer.format
     if format and format in ('csv', 'xls', 'xlsx'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ elasticsearch==2.4.1
 requests==2.14.2
 urllib3==1.21.1
 django-localflavor==1.5
+wagtail-flags==2.0.5


### PR DESCRIPTION
## Additions:
- Added logic to compare if `last_updated` is stale
- Added a link to CCDB_TECHNICAL_ISSUES flag to manually indicate data is invalid
- Added two items in `_meta`: 
  - `is_data_stale`: check if data is older than 4 business days, true if so
  - `has_data_issue`: check if CCDB_TECHNICAL_ISSUES flag has been turned on, true if so

## Changes:
- Made a few public functions private (with the `_`)
