### PR TITLE
Issue #39: Fix sort by date

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -154,6 +154,16 @@ class SearchBuilder(BaseBuilder):
 
         return highlight
 
+    def _build_sort(self):
+        sort_field_mapping = {
+            "relevance": "_score",
+            "created_date": "date_received"
+        }
+
+        sort_field, sort_order = self.params.get("sort").rsplit("_", 1)
+        sort_field = sort_field_mapping.get(sort_field, "_score")
+        return [{sort_field: {"order": sort_order}}]
+
     def build(self):
         search = {
             "from": self.params.get("frm"), 
@@ -173,9 +183,7 @@ class SearchBuilder(BaseBuilder):
         search["highlight"] = self._build_highlight()
 
         # sort
-        sort_field, sort_order = self.params.get("sort").rsplit("_", 1)
-        sort_field = "_score" if sort_field == "relevance" else sort_field
-        search["sort"] = [{sort_field: {"order": sort_order}}]
+        search["sort"] = self._build_sort()
 
         # query
         search_term = self.params.get("search_term")

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -308,8 +308,8 @@ class EsInterfaceTest(TestCase):
         sort_fields = [
             ("relevance_desc", "_score", "desc"), 
             ("relevance_asc", "_score", "asc"), 
-            ("created_date_desc", "created_date", "desc"), 
-            ("created_date_asc", "created_date", "asc")
+            ("created_date_desc", "date_received", "desc"), 
+            ("created_date_asc", "date_received", "asc")
         ]
 
         # 4 is the length of sort_field


### PR DESCRIPTION
This is to fix issue #39.

The reason is that the wrong field name was passed in ES when sorting.

## Changes:
- Use `date_received` instead of `created_date` when sorting in ES