### PR TITLE
Add Rate Throttling

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -8,6 +8,7 @@ export ES_HOST=localhost
 # export ES_PASSWORD=<Elasticsearch_authorized_password>
 # export COMPLAINT_ES_INDEX=<Complaint_index>
 # export COMPLAINT_DOC_TYPE=<Complaint_doctype>
+export CCDB_UI_URL=http://localhost:8000/data-research/consumer-complaints/search
 
 ###########################################################################
 # Virtual Environment - for keeping all dependencies within.

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -1,15 +1,26 @@
 from django.core.urlresolvers import reverse
+from django.core.cache import cache
 from rest_framework import status
 from rest_framework.test import APITestCase
 from unittest import skip
 from elasticsearch import TransportError
 import mock
 from complaint_search.es_interface import document
+from complaint_search.throttling import (
+    DocumentAnonRateThrottle,
+    _CCDB_UI_URL,
+)
 
 class DocumentTests(APITestCase):
 
     def setUp(self):
-        pass
+        self.orig_document_anon_rate = DocumentAnonRateThrottle.rate
+        # Setting rates to something really big so it doesn't affect testing
+        DocumentAnonRateThrottle.rate = '2000/min'
+
+    def tearDown(self):
+        cache.clear()
+        DocumentAnonRateThrottle.rate = self.orig_document_anon_rate
 
     @mock.patch('complaint_search.es_interface.document')
     def test_document__valid(self, mock_esdocument):
@@ -22,6 +33,43 @@ class DocumentTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_esdocument.assert_called_once_with("123456")
         self.assertEqual('OK', response.data)
+
+
+    @mock.patch('complaint_search.es_interface.document')
+    def test_document_with_document_anon_rate_throttle(self, mock_esdocument):
+        url = reverse('complaint_search:document', kwargs={"id": "123456"})
+        mock_esdocument.return_value = 'OK'
+        DocumentAnonRateThrottle.rate = self.orig_document_anon_rate
+        limit = int(self.orig_document_anon_rate.split('/')[0])
+        for i in range(limit):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual('OK', response.data)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 429)
+        self.assertIsNotNone(response.data.get('detail'))
+        self.assertIn("Request was throttled", response.data.get('detail'))
+        self.assertEqual(limit, mock_esdocument.call_count)
+        self.assertEqual(5, limit)
+
+    @mock.patch('complaint_search.es_interface.document')
+    def test_document_with_document_ui_rate_throttle(self, mock_esdocument):
+        url = reverse('complaint_search:document', kwargs={"id": "123456"})
+        mock_esdocument.return_value = 'OK'
+
+        DocumentAnonRateThrottle.rate = self.orig_document_anon_rate
+        limit = int(self.orig_document_anon_rate.split('/')[0])
+        for _ in range(limit):
+            response = self.client.get(url, HTTP_REFERER=_CCDB_UI_URL)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual('OK', response.data)
+
+        response = self.client.get(url, HTTP_REFERER=_CCDB_UI_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual('OK', response.data)
+        self.assertEqual(limit + 1, mock_esdocument.call_count)
+        self.assertEqual(5, limit)
 
     @mock.patch('complaint_search.es_interface.document')
     def test_document__transport_error_with_status_code(self, mock_esdocument):

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -47,7 +47,7 @@ class DocumentTests(APITestCase):
             self.assertEqual('OK', response.data)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertIsNotNone(response.data.get('detail'))
         self.assertIn("Request was throttled", response.data.get('detail'))
         self.assertEqual(limit, mock_esdocument.call_count)

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -559,7 +559,7 @@ class SearchTests(APITestCase):
             self.assertEqual('OK', response.data)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertIsNotNone(response.data.get('detail'))
         self.assertIn("Request was throttled", response.data.get('detail'))
         self.assertEqual(limit, mock_essearch.call_count)
@@ -599,7 +599,7 @@ class SearchTests(APITestCase):
             self.assertEqual('OK', response.data)
 
         response = self.client.get(url, {"format": "csv"})
-        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertIsNotNone(response.data.get('detail'))
         self.assertIn("Request was throttled", response.data.get('detail'))
         self.assertEqual(limit, mock_essearch.call_count)
@@ -619,7 +619,7 @@ class SearchTests(APITestCase):
             self.assertEqual('OK', response.data)
 
         response = self.client.get(url, {"format": "csv"}, HTTP_REFERER=_CCDB_UI_URL)
-        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertIsNotNone(response.data.get('detail'))
         self.assertIn("Request was throttled", response.data.get('detail'))
         self.assertEqual(limit, mock_essearch.call_count)

--- a/complaint_search/throttling.py
+++ b/complaint_search/throttling.py
@@ -1,0 +1,82 @@
+import os
+from rest_framework.throttling import AnonRateThrottle
+
+_CCDB_UI_URL = os.environ.get('CCDB_UI_URL', 
+    'http://localhost:8000/data-research/consumer-complaints/search')
+
+class CCDBRateThrottle(AnonRateThrottle):
+    scope = 'ccdb'
+
+    def is_referred_from_ui(self, request,view):
+        return request.META.get('HTTP_REFERER') and \
+            request.META.get('HTTP_REFERER').find(_CCDB_UI_URL) != -1
+
+    def is_export(self, request): # otherwise it is a search
+        return request.query_params.get("format") and \
+            request.query_params.get("format") in ('json', 'csv', 'xls', 'xlsx')
+  
+class CCDBAnonRateThrottle(CCDBRateThrottle):
+    scope = 'ccdb_anon'
+
+    def allow_request(self, request, view):
+        if not self.is_referred_from_ui(request, view):
+            return super(CCDBAnonRateThrottle, self).allow_request(request, view)
+        else:
+            return True
+
+class CCDBUIRateThrottle(CCDBRateThrottle):
+    scope = 'ccdb_ui'
+
+    def allow_request(self, request, view):
+        if self.is_referred_from_ui(request, view):
+            return super(CCDBUIRateThrottle, self).allow_request(request, view)
+        else:
+            return True
+
+class SearchUIRateThrottle(CCDBUIRateThrottle):
+    scope = 'ccdb_ui_search'
+    # rate needs to be set if use
+
+    def allow_request(self, request, view):
+        if not self.is_export(request):
+            return super(SearchUIRateThrottle, self).allow_request(request, view)
+        else:
+            return True
+
+class SearchAnonRateThrottle(CCDBAnonRateThrottle):
+    scope = 'ccdb_anon_search'
+    rate = '20/min'
+
+    def allow_request(self, request, view):
+        if not self.is_export(request):
+            return super(SearchAnonRateThrottle, self).allow_request(request, view)
+        else:
+            return True
+
+class ExportUIRateThrottle(CCDBUIRateThrottle):
+    scope = 'ccdb_ui_export'
+    rate = '6/min'
+
+    def allow_request(self, request, view):
+        if self.is_export(request):
+            return super(ExportUIRateThrottle, self).allow_request(request, view)
+        else:
+            return True
+
+class ExportAnonRateThrottle(CCDBAnonRateThrottle):
+    scope = 'ccdb_anon_export'
+    rate = '2/min'
+
+    def allow_request(self, request, view):
+        if self.is_export(request):
+            return super(ExportAnonRateThrottle, self).allow_request(request, view)
+        else:
+            return True
+
+class DocumentUIRateThrottle(CCDBUIRateThrottle):
+    scope = 'ccdb_ui_document'
+    # rate needs to be set if use
+
+class DocumentAnonRateThrottle(CCDBAnonRateThrottle):
+    scope = 'ccdb_anon_document'
+    rate = '5/min'

--- a/complaint_search/throttling.py
+++ b/complaint_search/throttling.py
@@ -33,15 +33,15 @@ class CCDBUIRateThrottle(CCDBRateThrottle):
         else:
             return True
 
-class SearchUIRateThrottle(CCDBUIRateThrottle):
-    scope = 'ccdb_ui_search'
-    # rate needs to be set if use
+# class SearchUIRateThrottle(CCDBUIRateThrottle):
+#     scope = 'ccdb_ui_search'
+#     # rate needs to be set if use
 
-    def allow_request(self, request, view):
-        if not self.is_export(request):
-            return super(SearchUIRateThrottle, self).allow_request(request, view)
-        else:
-            return True
+#     def allow_request(self, request, view):
+#         if not self.is_export(request):
+#             return super(SearchUIRateThrottle, self).allow_request(request, view)
+#         else:
+#             return True
 
 class SearchAnonRateThrottle(CCDBAnonRateThrottle):
     scope = 'ccdb_anon_search'
@@ -73,9 +73,9 @@ class ExportAnonRateThrottle(CCDBAnonRateThrottle):
         else:
             return True
 
-class DocumentUIRateThrottle(CCDBUIRateThrottle):
-    scope = 'ccdb_ui_document'
-    # rate needs to be set if use
+# class DocumentUIRateThrottle(CCDBUIRateThrottle):
+#     scope = 'ccdb_ui_document'
+#     # rate needs to be set if use
 
 class DocumentAnonRateThrottle(CCDBAnonRateThrottle):
     scope = 'ccdb_anon_document'


### PR DESCRIPTION
This implements rate limiting for the API:

**For anonymous user**: 
Export: 2 / minute
Detail: 5 / second
Search: 20 / minute
Suggest: Unlimited

**For UI**:
Export: 6 / minute
Detail: Unlimited
Search: Unlimited
Suggest: Unlimited

## Additions:
- Added new rate throttle classes for each scenario
- Added corresponding tests

## Notes:
- A corresponding addition will also be added in the environment for cfgov-refresh so it has the correct location of the referer