### PR TITLE
Narrative warning

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -58,7 +58,13 @@ def _get_meta():
         "aggs": {
             "max_date" : { "max" : { "field" : "date_received" }},
             "max_update": { "max" : { "field" : ":updated_at" }},
-            "max_created": { "max" : { "field" : ":created_at" }}
+            "max_created": { "max" : { "field" : ":created_at" }},
+            "max_narratives": {
+                "filter" : { "term" : { "has_narrative" : "true" }},
+                "aggs" : {
+                    "max_date" : { "max" : { "field" : "date_received" }}
+                }
+            }
         }
     }
     max_date_res = _get_es().search(index=_COMPLAINT_ES_INDEX, body=body)
@@ -68,6 +74,7 @@ def _get_meta():
     result = {
         "license": "CC0",
         "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
+        "last_updated_narratives": max_date_res["aggregations"]["max_narratives"]["max_date"]["value_as_string"],
         "total_record_count": count_res["count"],
         "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_date"]["value_as_string"]),
         "has_data_issue": flag_enabled('CCDB_TECHNICAL_ISSUES')

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -51,6 +51,13 @@ def _is_data_stale(last_updated_time):
 
     return False
 
+def from_timestamp(seconds):
+    if seconds == 0:
+        return 'N/A'
+    else:
+        fromtimestamp = datetime.fromtimestamp(seconds)
+        return fromtimestamp.strftime('%Y-%m-%d')
+
 def _get_meta():
     body = {
         # size: 0 here to prevent taking too long since we only needed max_date
@@ -62,7 +69,7 @@ def _get_meta():
             "max_narratives": {
                 "filter" : { "term" : { "has_narrative" : "true" }},
                 "aggs" : {
-                    "max_date" : { "max" : { "field" : "date_received" }}
+                    "max_date" : { "max" : { "field" : ":updated_at" }}
                 }
             }
         }
@@ -74,7 +81,7 @@ def _get_meta():
     result = {
         "license": "CC0",
         "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
-        "last_updated_narratives": max_date_res["aggregations"]["max_narratives"]["max_date"]["value_as_string"],
+        "last_updated_narratives": from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"]),
         "total_record_count": count_res["count"],
         "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_date"]["value_as_string"]),
         "has_data_issue": flag_enabled('CCDB_TECHNICAL_ISSUES')

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -52,11 +52,8 @@ def _is_data_stale(last_updated_time):
     return False
 
 def from_timestamp(seconds):
-    if seconds == 0:
-        return 'N/A'
-    else:
-        fromtimestamp = datetime.fromtimestamp(seconds)
-        return fromtimestamp.strftime('%Y-%m-%d')
+    fromtimestamp = datetime.fromtimestamp(seconds)
+    return fromtimestamp.strftime('%Y-%m-%d')
 
 def _get_meta():
     body = {

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -81,9 +81,8 @@ def _get_meta():
     result = {
         "license": "CC0",
         "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
-        "last_updated_narratives": from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"]),
         "total_record_count": count_res["count"],
-        "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_date"]["value_as_string"]),
+        "is_data_stale": _is_data_stale(from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"])),
         "has_data_issue": flag_enabled('CCDB_TECHNICAL_ISSUES')
     }
 

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -36,6 +36,11 @@ class EsInterfaceTest(TestCase):
             "aggregations": {
                 "max_date": {
                     "value_as_string": "2017-01-01"
+                },
+                "max_narratives": {
+                    "max_date" : {
+                        "value": 1507011188.0
+                    }
                 }
             }
         }
@@ -104,7 +109,7 @@ class EsInterfaceTest(TestCase):
     def test_get_meta_data_stale(self, mock_count, mock_search, mock_now):
         mock_search.return_value = self.MOCK_SEARCH_SIDE_EFFECT[1]
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_now.return_value = datetime(2017, 1, 10)
+        mock_now.return_value = datetime(2017, 11, 1)
 
         res = _get_meta()
         exp_res = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])


### PR DESCRIPTION
Aggregates the `:updated_at` date of all complaints that have narratives, and then determines if the most recent date of that aggregation is older than five business days. It sets the `is_data_stale` flag in the metadata, which will trigger a warning message being displayed by CCDB5-UI