### PR TITLE
Remove Zip Code Aggs

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -109,7 +109,7 @@ def _get_meta():
 # - has_narrative: filters a list of whether complaint has narratives or not
 # - submitted_via: filters a list of ways the complaint was submitted
 # - tags - filters a list of tags
-def search(**kwargs):
+def search(agg_exclude=None, **kwargs):
     params = copy.deepcopy(PARAMS)
     params.update(**kwargs)
     search_builder = SearchBuilder()
@@ -126,6 +126,8 @@ def search(**kwargs):
         if not params.get("no_aggs"):
             aggregation_builder = AggregationBuilder()
             aggregation_builder.add(**params)
+            if agg_exclude:
+                aggregation_builder.add_exclude(agg_exclude)
             body["aggs"] = aggregation_builder.build()
 
         res = _get_es().search(index=_COMPLAINT_ES_INDEX,

--- a/complaint_search/tests/expected_results/search_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_agg_exclude__valid.json
@@ -1,0 +1,257 @@
+{
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "from": 0,
+  "aggs": {
+    "timely": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      }
+    },
+    "company_public_response": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "product": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    "tags": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      }
+    },
+    "company": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "company": {
+          "terms": {
+            "field": "company.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "consumer_disputed": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "state": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      }
+    },
+    "has_narrative": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      }
+    },
+    "submitted_via": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      }
+    },
+    "issue": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    "company_response": {
+      "filter": {
+        "bool": {
+          "filter": [],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "query_string": {
+      "query": "*",
+      "default_operator": "AND",
+      "fields": [
+        "complaint_what_happened"
+      ]
+    }
+  },
+  "post_filter": {
+    "bool": {
+      "filter": [],
+      "must": [],
+      "should": []
+    }
+  },
+  "highlight": {
+    "fragment_size": 500,
+    "number_of_fragments": 1,
+    "require_field_match": false,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "size": 10
+}

--- a/complaint_search/tests/expected_results/search_with_zip_code_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code_agg_exclude__valid.json
@@ -1,0 +1,470 @@
+{
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "from": 0,
+  "aggs": {
+    "timely": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      }
+    },
+    "company_public_response": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "product": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    "tags": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      }
+    },
+    "company": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "company": {
+          "terms": {
+            "field": "company.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "consumer_disputed": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      }
+    },
+    "state": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      }
+    },
+    "has_narrative": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      }
+    },
+    "submitted_via": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      }
+    },
+    "issue": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    "company_response": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      }
+    },
+    "zip_code": {
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "zip_code": [
+                      "12345",
+                      "23435",
+                      "03433"
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must": []
+        }
+      },
+      "aggs": {
+        "zip_code": {
+          "terms": {
+            "field": "zip_code",
+            "size": 0
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "query_string": {
+      "query": "*",
+      "default_operator": "AND",
+      "fields": [
+        "complaint_what_happened"
+      ]
+    }
+  },
+  "post_filter": {
+    "bool": {
+      "filter": [
+        {
+          "bool": {
+            "should": {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "must": [],
+      "should": []
+    }
+  },
+  "highlight": {
+    "fragment_size": 500,
+    "number_of_fragments": 1,
+    "require_field_match": false,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "size": 10
+}

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -40,6 +40,10 @@ class SearchTests(APITestCase):
         params.update(overrides)
         return params
 
+    def buildDefaultAggExclude(self, addl_exclude_list=[]):
+        agg_exclude = set(['zip_code'] + addl_exclude_list)
+        return list(agg_exclude)
+
     @mock.patch('complaint_search.es_interface.search')
     def test_search_no_param(self, mock_essearch):
         """
@@ -49,7 +53,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({}))
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({}))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -103,7 +108,8 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(**self.buildDefaultParams({
+        calls = [ mock.call(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "field": SearchInputSerializer.FIELD_MAP.get(field_pair[0],
                 field_pair[0])}))
             for field_pair in SearchInputSerializer.FIELD_CHOICES ]
@@ -127,7 +133,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -137,7 +144,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -182,7 +190,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -242,7 +251,8 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(**self.buildDefaultParams({"sort": sort_pair[0]}))
+        calls = [ mock.call(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({"sort": sort_pair[0]}))
             for sort_pair in SearchInputSerializer.SORT_CHOICES ]
         mock_essearch.assert_has_calls(calls)
 
@@ -264,7 +274,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams(params))
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -274,7 +285,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "date_received_min": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
@@ -296,7 +308,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "date_received_max": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
@@ -318,7 +331,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "company_received_min": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
@@ -340,7 +354,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "company_received_max": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
 
@@ -362,7 +377,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "company": ["One Bank", "Bank 2"]}))
         self.assertEqual('OK', response.data)
 
@@ -376,7 +392,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
             "product": ["Mortgage-FHA Mortgage", "Payday Loan"]}))
         self.assertEqual('OK', response.data)
 
@@ -392,7 +409,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "issue": ["Communication tactics-Frequent or repeated calls",
             "Loan servicing, payments, escrow account"]}))
         self.assertEqual('OK', response.data)
@@ -405,7 +423,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "state": ["CA", "FL", "VA"]}))
         self.assertEqual('OK', response.data)
 
@@ -417,7 +436,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "zip_code": ["94XXX", "24236", "23456"]}))
         self.assertEqual('OK', response.data)
 
@@ -429,7 +449,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "timely": ["YES", "NO"]}))
         self.assertEqual('OK', response.data)
 
@@ -441,7 +462,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "consumer_disputed": ["yes", "no"]}))
         self.assertEqual('OK', response.data)
 
@@ -453,7 +475,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "company_response": ["Closed", "No response"]}))
         self.assertEqual('OK', response.data)
 
@@ -465,7 +488,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "company_public_response": ["Closed", "No response"]}))
         self.assertEqual('OK', response.data)
 
@@ -477,7 +501,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "consumer_consent_provided": ["Yes", "No"]}))
         self.assertEqual('OK', response.data)
 
@@ -489,7 +514,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "has_narrative": ["Yes", "No"]}))
         self.assertEqual('OK', response.data)
 
@@ -501,7 +527,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "submitted_via": ["Web", "Phone"]}))
         self.assertEqual('OK', response.data)
 
@@ -513,7 +540,8 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "tags": ["Older American", "Servicemember"]}))
         self.assertEqual('OK', response.data)
 
@@ -524,7 +552,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "no_aggs": True}))
         self.assertEqual('OK', response.data)
 
@@ -546,7 +575,8 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(**self.buildDefaultParams({
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+            **self.buildDefaultParams({
                 "no_highlight": True}))
         self.assertEqual('OK', response.data)
 

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -126,7 +126,10 @@ def search(request):
     serializer = SearchInputSerializer(data=data)
 
     if serializer.is_valid():
-        results = es_interface.search(**serializer.validated_data)
+        agg_exclude = []
+        agg_exclude.append('zip_code')
+
+        results = es_interface.search(agg_exclude=agg_exclude, **serializer.validated_data)
 
         headers = _buildHeaders()
 


### PR DESCRIPTION
This will remove the zip code aggregations if zip_code is not a filter.  If zip_code is a filter, it will include only aggregations for those specific filters.

## Additions:
- Added logic to remove zip_code if it is a filter
- Added logic to include zip_code term/filter aggregation if it is a filter