### PR TITLE
Convert content to stream

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -60,3 +60,12 @@ CSV_ORDERED_HEADERS = OrderedDict([
     ("consumer_disputed", "Consumer disputed?"),
     ("complaint_id", "Complaint ID")
 ])
+
+AGG_EXCLUDE_FIELDS = ['company', 'zip_code']
+
+CHUNK_SIZE = 512
+
+FORMAT_CONTENT_TYPE_MAP = {
+    "json": "application/json",
+    "csv": "text/csv",
+}

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -4,10 +4,10 @@ import json
 import abc
 from collections import defaultdict, namedtuple
 from complaint_search.defaults import (
-    PARAMS, 
-    DELIMITER, 
-    SOURCE_FIELDS,
-    EXPORT_FORMATS
+    DELIMITER,
+    EXPORT_FORMATS,
+    PARAMS,
+    SOURCE_FIELDS
 )
 
 

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -14,9 +14,10 @@ from complaint_search.es_builders import (
     AggregationBuilder
 )
 from complaint_search.defaults import (
-    PARAMS, 
+    CHUNK_SIZE,
+    CSV_ORDERED_HEADERS,
     EXPORT_FORMATS,
-    CSV_ORDERED_HEADERS
+    PARAMS,
 )
 from stream_content import StreamContent
 
@@ -175,8 +176,7 @@ def search(agg_exclude=None, **kwargs):
                                          _COMPLAINT_DOC_TYPE, p)
         response = requests.get(url, auth=(_ES_USER, _ES_PASSWORD), stream=True)
         if response.ok:
-            print response.headers['content-length']
-            res = response.iter_content(chunk_size=512)
+            res = response.iter_content(chunk_size=CHUNK_SIZE)
             if format == "csv":
                 readable_header = ",".join('"' + rfield + '"' 
                     for rfield in CSV_ORDERED_HEADERS.values()) + "\n"

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -18,6 +18,7 @@ from complaint_search.defaults import (
     EXPORT_FORMATS,
     CSV_ORDERED_HEADERS
 )
+from stream_content import StreamContent
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'),
                               os.environ.get('ES_PORT', '9200'))
@@ -172,13 +173,14 @@ def search(agg_exclude=None, **kwargs):
 
         url = "{}/{}/{}/_data?{}".format(_ES_URL, _COMPLAINT_ES_INDEX,
                                          _COMPLAINT_DOC_TYPE, p)
-        response = requests.get(url, auth=(_ES_USER, _ES_PASSWORD))
+        response = requests.get(url, auth=(_ES_USER, _ES_PASSWORD), stream=True)
         if response.ok:
-            res = response.content
+            print response.headers['content-length']
+            res = response.iter_content(chunk_size=512)
             if format == "csv":
                 readable_header = ",".join('"' + rfield + '"' 
                     for rfield in CSV_ORDERED_HEADERS.values()) + "\n"
-                res =  readable_header + res
+                res = StreamContent(readable_header, res)
     return res
 
 

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -1,0 +1,15 @@
+class StreamContent(object):
+    def __init__(self, header, content):
+        self.header = header
+        self.content = content
+        self.is_header_returned = False
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        if self.header and not self.is_header_returned:
+            self.is_header_returned = True
+            return self.header
+        else:
+            return next(self.content)

--- a/complaint_search/tests/test_stream_content.py
+++ b/complaint_search/tests/test_stream_content.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from complaint_search.stream_content import StreamContent
+
+class StreamContentTests(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_iter(self):
+        sc = StreamContent(None, iter([1,2,3]))
+        self.assertTrue(isinstance(iter(sc), StreamContent))
+
+    def test_next_no_header(self):
+        sc = StreamContent(None, iter([1,2,3]))
+        content = [ item for item in sc ]
+        self.assertListEqual([1,2,3], content)
+
+
+    def test_next_header(self):
+        sc = StreamContent("header", iter([1,2,3]))
+        content = [ item for item in sc ]
+        self.assertListEqual(["header",1,2,3], content)

--- a/complaint_search/throttling.py
+++ b/complaint_search/throttling.py
@@ -1,5 +1,6 @@
 import os
 from rest_framework.throttling import AnonRateThrottle
+from complaint_search.defaults import EXPORT_FORMATS
 
 _CCDB_UI_URL = os.environ.get('CCDB_UI_URL', 
     'http://localhost:8000/data-research/consumer-complaints/search')
@@ -13,7 +14,7 @@ class CCDBRateThrottle(AnonRateThrottle):
 
     def is_export(self, request): # otherwise it is a search
         return request.query_params.get("format") and \
-            request.query_params.get("format") in ('json', 'csv', 'xls', 'xlsx')
+            request.query_params.get("format") in EXPORT_FORMATS
   
 class CCDBAnonRateThrottle(CCDBRateThrottle):
     scope = 'ccdb_anon'

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -9,7 +9,11 @@ from django.conf import settings
 from datetime import datetime
 from elasticsearch import TransportError
 import es_interface
-from complaint_search.defaults import EXPORT_FORMATS
+from complaint_search.defaults import (
+    AGG_EXCLUDE_FIELDS,
+    EXPORT_FORMATS,
+    FORMAT_CONTENT_TYPE_MAP
+)
 from complaint_search.renderers import (
     DefaultRenderer, CSVRenderer
 )
@@ -111,7 +115,6 @@ def _buildHeaders():
 def search(request):
 
     fixed_qparam = request.query_params
-
     data = _parse_query_params(request.query_params)
 
     # Add format to data
@@ -123,45 +126,34 @@ def search(request):
 
     serializer = SearchInputSerializer(data=data)
 
-    if serializer.is_valid():
-        agg_exclude = ['company', 'zip_code']
-
-        results = es_interface.search(agg_exclude=agg_exclude, **serializer.validated_data)
-
-        headers = _buildHeaders()
-
-        # If format is in export formats, update its attachment response
-        # with a filename
-        if format in EXPORT_FORMATS:
-
-            FORMAT_CONTENT_TYPE_MAP = {
-                "json": "application/json",
-                "csv": "text/csv",
-            }
-
-            response = StreamingHttpResponse(
-                streaming_content=results,
-                content_type=FORMAT_CONTENT_TYPE_MAP[format]
-            )
-            filename = 'complaints-{}.{}'.format(
-                datetime.now().strftime('%Y-%m-%d_%H_%M'), format
-            )
-            headerTemplate = 'attachment; filename="{}"'
-            response['Content-Disposition'] = headerTemplate.format(filename)
-            for header in headers:
-                response[header] = headers[header]
-
-            return response
-
-        else:
-
-        return Response(results, headers=headers)
-
-    else:
+    if not serializer.is_valid():
         return Response(
             serializer.errors, status=status.HTTP_400_BAD_REQUEST
         )
+ 
+    results = es_interface.search(
+        agg_exclude=AGG_EXCLUDE_FIELDS, **serializer.validated_data)
+    headers = _buildHeaders()
 
+    if format not in EXPORT_FORMATS:
+        return Response(results, headers=headers)
+
+    # If format is in export formats, update its attachment response
+    # with a filename
+
+    response = StreamingHttpResponse(
+        streaming_content=results,
+        content_type=FORMAT_CONTENT_TYPE_MAP[format]
+    )
+    filename = 'complaints-{}.{}'.format(
+        datetime.now().strftime('%Y-%m-%d_%H_%M'), format
+    )
+    headerTemplate = 'attachment; filename="{}"'
+    response['Content-Disposition'] = headerTemplate.format(filename)
+    for header in headers:
+        response[header] = headers[header]
+
+    return response
 
 @api_view(['GET'])
 @catch_es_error


### PR DESCRIPTION
Content from Data format plugin was originally downloaded completely before passing to the view to return as a response.  This means a large chunk of memory is being passed along this process.  To prevent stressing the server, streaming content is introduced.  The content from data format plugin is now downloaded in chunk, and an iterator is used for this purpose.  The same iterator + header is then passed to export API response directly as a streaming response.  This way we will download (from data format plugin) in a small chunk then pass the same small chunk to streaming response directly.

## Additions:
- Created a wrapper iterator for content that needs to have additional header to iterate over before the content (i.e. csv)

## Changes:
- Made the get requests to data format plugin as streaming
- Converted non-default format to use StreamingHttpResponse instead of DRF Response
- Refactored code