### PR TITLE
JSON export needs to be reformatted

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -168,8 +168,8 @@ def search(agg_exclude=None, **kwargs):
         del(body["from"])
 
         p = {
-            "format": format, 
-            "source": json.dumps(body), 
+            "format": format,
+            "source": json.dumps(body),
             "fl": ",".join(field for field in CSV_ORDERED_HEADERS.keys()),
             "append.header": "false"
         }
@@ -177,14 +177,15 @@ def search(agg_exclude=None, **kwargs):
 
         url = "{}/{}/{}/_data?{}".format(_ES_URL, _COMPLAINT_ES_INDEX,
                                          _COMPLAINT_DOC_TYPE, p)
-        response = requests.get(url, auth=(_ES_USER, _ES_PASSWORD), stream=True)
+        response = requests.get(url, auth=(
+            _ES_USER, _ES_PASSWORD), stream=True)
         if response.ok:
             res = response.iter_content(chunk_size=CHUNK_SIZE)
             if format == "json":
                 res = StreamJSONContent(res)
             elif format == "csv":
-                readable_header = ",".join('"' + rfield + '"' 
-                    for rfield in CSV_ORDERED_HEADERS.values()) + "\n"
+                readable_header = ",".join('"' + rfield + '"'
+                                           for rfield in CSV_ORDERED_HEADERS.values()) + "\n"
                 res = StreamCSVContent(readable_header, res)
     return res
 

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -11,7 +11,7 @@ from flags.state import flag_enabled
 from complaint_search.es_builders import (
     SearchBuilder,
     PostFilterBuilder,
-    AggregationBuilder
+    AggregationBuilder,
 )
 from complaint_search.defaults import (
     CHUNK_SIZE,
@@ -19,7 +19,10 @@ from complaint_search.defaults import (
     EXPORT_FORMATS,
     PARAMS,
 )
-from stream_content import StreamContent
+from stream_content import (
+    StreamCSVContent,
+    StreamJSONContent,
+)
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'),
                               os.environ.get('ES_PORT', '9200'))
@@ -177,10 +180,12 @@ def search(agg_exclude=None, **kwargs):
         response = requests.get(url, auth=(_ES_USER, _ES_PASSWORD), stream=True)
         if response.ok:
             res = response.iter_content(chunk_size=CHUNK_SIZE)
-            if format == "csv":
+            if format == "json":
+                res = StreamJSONContent(res)
+            elif format == "csv":
                 readable_header = ",".join('"' + rfield + '"' 
                     for rfield in CSV_ORDERED_HEADERS.values()) + "\n"
-                res = StreamContent(readable_header, res)
+                res = StreamCSVContent(readable_header, res)
     return res
 
 

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -30,6 +30,7 @@ class StreamJSONContent(object):
             first_eol_index = self.complaint_in_progress.index('\n')
             
             # see if we have 2nd completed line, and that's the complaint we want to return
+            # assuming at the EOF there's also a '\n' as seen from data format plugin so far
             second_eol_index = self.complaint_in_progress.index('\n', first_eol_index + 1)
 
             complaint = self.complaint_in_progress[first_eol_index + 1:second_eol_index + 1].strip()

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -1,6 +1,5 @@
-import re
-
 class StreamCSVContent(object):
+
     def __init__(self, header, content):
         self.header = header
         self.content = content
@@ -16,7 +15,9 @@ class StreamCSVContent(object):
         else:
             return next(self.content)
 
+
 class StreamJSONContent(object):
+
     def __init__(self, content):
         self.content = content
         self.complaint_in_progress = ""
@@ -28,17 +29,22 @@ class StreamJSONContent(object):
         # see if first line is reached
         try:
             first_eol_index = self.complaint_in_progress.index('\n')
-            
-            # see if we have 2nd completed line, and that's the complaint we want to return
-            # assuming at the EOF there's also a '\n' as seen from data format plugin so far
-            second_eol_index = self.complaint_in_progress.index('\n', first_eol_index + 1)
 
-            complaint = self.complaint_in_progress[first_eol_index + 1:second_eol_index + 1].strip()
+            # see if we have 2nd completed line, and that's the complaint we want to return
+            # assuming at the EOF there's also a '\n' as seen from data format
+            # plugin so far
+            second_eol_index = self.complaint_in_progress.index(
+                '\n', first_eol_index + 1)
+
+            complaint = self.complaint_in_progress[
+                first_eol_index + 1:second_eol_index + 1].strip()
             # save the rest for next iteration
-            self.complaint_in_progress = self.complaint_in_progress[second_eol_index + 1:]
+            self.complaint_in_progress = self.complaint_in_progress[
+                second_eol_index + 1:]
             return complaint
         except ValueError:
-            # This means cannot find two \n, complaint is not ready, need more data
+            # This means cannot find two \n, complaint is not ready, need more
+            # data
             return None
 
     def __iter__(self):
@@ -73,4 +79,3 @@ class StreamJSONContent(object):
                     return "]"
                 else:
                     raise StopIteration
-

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -1,4 +1,6 @@
-class StreamContent(object):
+import re
+
+class StreamCSVContent(object):
     def __init__(self, header, content):
         self.header = header
         self.content = content
@@ -13,3 +15,61 @@ class StreamContent(object):
             return self.header
         else:
             return next(self.content)
+
+class StreamJSONContent(object):
+    def __init__(self, content):
+        self.content = content
+        self.complaint_in_progress = ""
+        self.is_streaming_started = False
+        self.is_streaming_stopped = False
+
+    def get_next_complaint(self):
+        self.complaint_in_progress = self.complaint_in_progress.lstrip()
+        # see if first line is reached
+        try:
+            first_eol_index = self.complaint_in_progress.index('\n')
+            
+            # see if we have 2nd completed line, and that's the complaint we want to return
+            second_eol_index = self.complaint_in_progress.index('\n', first_eol_index + 1)
+
+            complaint = self.complaint_in_progress[first_eol_index + 1:second_eol_index + 1].strip()
+            # save the rest for next iteration
+            self.complaint_in_progress = self.complaint_in_progress[second_eol_index + 1:]
+            return complaint
+        except ValueError:
+            # This means cannot find two \n, complaint is not ready, need more data
+            return None
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        while True:
+            if not self.is_streaming_started:
+                # This is the beginning
+                self.is_streaming_started = True
+                return "["
+            try:
+                next_chunk = next(self.content)
+                self.complaint_in_progress += next_chunk
+                # peek ahead, it will raise StopIteration if no more chunk
+                next2_chunk = next(self.content)
+                complaint = self.get_next_complaint()
+                self.complaint_in_progress += next2_chunk
+                if complaint and self.complaint_in_progress.strip():
+                    return complaint + ","
+                elif complaint and not self.complaint_in_progress.strip():
+                    return complaint
+            except StopIteration:
+                complaint = self.get_next_complaint()
+                if complaint and not self.complaint_in_progress.strip():
+                    return complaint
+                elif complaint and self.complaint_in_progress.strip():
+                    return complaint + ","
+                elif not self.is_streaming_stopped:
+                    # This is the end
+                    self.is_streaming_stopped = True
+                    return "]"
+                else:
+                    raise StopIteration
+

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -19,7 +19,10 @@ from complaint_search.defaults import (
     CSV_ORDERED_HEADERS,
     EXPORT_FORMATS
 )
-from complaint_search.stream_content import StreamCSVContent
+from complaint_search.stream_content import (
+    StreamCSVContent,
+    StreamJSONContent,
+)
 from datetime import datetime
 from elasticsearch import Elasticsearch
 from collections import namedtuple
@@ -221,7 +224,7 @@ class EsInterfaceTest_Search(TestCase):
         for format in format_list:
             res = search(format=format)
             expected_res = 'RGET_OK'
-            if format == 'csv':
+            if format =='csv':
 
                 expected_header = ",".join('"' + header + '"'
                     for header in CSV_ORDERED_HEADERS.values()) + "\n"
@@ -229,7 +232,8 @@ class EsInterfaceTest_Search(TestCase):
                 self.assertEqual(res.header, expected_header)
                 self.assertEqual(res.content, 'RGET_OK')
             else:
-                self.assertEqual(res, 'RGET_OK')
+                self.assertTrue(isinstance(res, StreamJSONContent))
+                self.assertEqual(res.content, 'RGET_OK')
 
             self.assertEqual(len(mock_jdump.call_args), 2)
             self.assertEqual(1, len(mock_jdump.call_args[0]))

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -19,7 +19,7 @@ from complaint_search.defaults import (
     CSV_ORDERED_HEADERS,
     EXPORT_FORMATS
 )
-from complaint_search.stream_content import StreamContent
+from complaint_search.stream_content import StreamCSVContent
 from datetime import datetime
 from elasticsearch import Elasticsearch
 from collections import namedtuple
@@ -225,7 +225,7 @@ class EsInterfaceTest_Search(TestCase):
 
                 expected_header = ",".join('"' + header + '"'
                     for header in CSV_ORDERED_HEADERS.values()) + "\n"
-                self.assertTrue(isinstance(res, StreamContent))
+                self.assertTrue(isinstance(res, StreamCSVContent))
                 self.assertEqual(res.header, expected_header)
                 self.assertEqual(res.content, 'RGET_OK')
             else:

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -71,7 +71,7 @@ class EsInterfaceTest_Search(TestCase):
                     "value_as_string": "2017-01-01"
                 },
                 "max_narratives": {
-                    "max_date" : {
+                    "max_date": {
                         "value": 1507011188.0
                     }
                 }
@@ -157,7 +157,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_no_param__valid(self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = load("search_no_param__valid")
         res = search()
@@ -185,7 +186,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_agg_exclude__valid(self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = load("search_agg_exclude__valid")
         res = search(agg_exclude=['zip_code'])
@@ -214,20 +216,21 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch('json.dumps')
     @mock.patch('urllib.urlencode')
     def test_search_with_format_nondefault__valid(self, mock_urlencode,
-        mock_jdump, mock_rget, mock_search):
+                                                  mock_jdump, mock_rget, mock_search):
         mock_search.return_value = 'OK'
         mock_jdump.return_value = 'JDUMPS_OK'
         RGet = namedtuple('RGet', 'ok, iter_content')
-        mock_rget.return_value = RGet(ok=True, iter_content=mock.MagicMock(return_value='RGET_OK'))
+        mock_rget.return_value = RGet(
+            ok=True, iter_content=mock.MagicMock(return_value='RGET_OK'))
         body = load("search_with_format_nondefault__valid")
         format_list = EXPORT_FORMATS
         for format in format_list:
             res = search(format=format)
             expected_res = 'RGET_OK'
-            if format =='csv':
+            if format == 'csv':
 
                 expected_header = ",".join('"' + header + '"'
-                    for header in CSV_ORDERED_HEADERS.values()) + "\n"
+                                           for header in CSV_ORDERED_HEADERS.values()) + "\n"
                 self.assertTrue(isinstance(res, StreamCSVContent))
                 self.assertEqual(res.header, expected_header)
                 self.assertEqual(res.content, 'RGET_OK')
@@ -259,6 +262,7 @@ class EsInterfaceTest_Search(TestCase):
 
         mock_search.assert_not_called()
         self.assertEqual(len(format_list), mock_rget.call_count)
+
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._get_meta")
     @mock.patch.object(Elasticsearch, 'search')
@@ -267,7 +271,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_field__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = load("search_with_field__valid")
         res = search(field="test_field")
@@ -296,7 +301,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_field_all__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = load("search_with_field_all__valid")
         res = search(field="_all")
@@ -332,7 +338,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_size__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_size__valid")
         res = search(size=40)
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -353,7 +360,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_frm__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.side_effect = copy.deepcopy(self.MOCK_SCROLL_SIDE_EFFECT)
         body = load("search_with_frm__valid")
         res = search(frm=20)
@@ -366,7 +374,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         self.assertEqual(mock_scroll.call_count, 2)
         search_result = copy.deepcopy(self.MOCK_SEARCH_RESULT)
-        search_result['hits']['hits'] = self.MOCK_SCROLL_SIDE_EFFECT[1]['hits']['hits']
+        search_result['hits'][
+            'hits'] = self.MOCK_SCROLL_SIDE_EFFECT[1]['hits']['hits']
         self.assertDictEqual(search_result, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
@@ -388,19 +397,20 @@ class EsInterfaceTest_Search(TestCase):
         # mock_count.side_effect = []
         # for i in range(4):
 
-        mock_search.side_effect = [ copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT[0])
-            for i in range(4) ]
+        mock_search.side_effect = [copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT[0])
+                                   for i in range(4)]
 
-        mock_count.side_effect = [ copy.deepcopy(self.MOCK_COUNT_RETURN_VALUE)
-            for i in range(4) ]
-        mock_get_meta.side_effect = [ copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
-            for i in range(4) ]
+        mock_count.side_effect = [copy.deepcopy(self.MOCK_COUNT_RETURN_VALUE)
+                                  for i in range(4)]
+        mock_get_meta.side_effect = [copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+                                     for i in range(4)]
         body = load("search_with_sort__valid")
 
         for s in sort_fields:
             res = search(sort=s[0])
             body["sort"] = [{s[1]: {"order": s[2]}}]
-            mock_search.assert_any_call(body=body, index="INDEX", doc_type=_COMPLAINT_DOC_TYPE, scroll="10m")
+            mock_search.assert_any_call(
+                body=body, index="INDEX", doc_type=_COMPLAINT_DOC_TYPE, scroll="10m")
             self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
         mock_scroll.assert_not_called()
@@ -414,7 +424,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_search_term_match__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_search_term_match__valid")
         res = search(search_term="test term")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -439,7 +450,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_search_term_qsq_and__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_search_term_qsq_and__valid")
         res = search(search_term="test AND term")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -464,7 +476,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_search_term_qsq_or__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_search_term_qsq_or__valid")
         res = search(search_term="test OR term")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -489,7 +502,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_search_term_qsq_not__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_search_term_qsq_not__valid")
         res = search(search_term="test NOT term")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -514,7 +528,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_search_term_qsq_to__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_search_term_qsq_to__valid")
         res = search(search_term="term TO test")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -539,7 +554,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_date_received_min__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_date_received_min__valid")
         res = search(date_received_min="2014-04-14")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -564,7 +580,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_date_received_max__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_date_received_max__valid")
         res = search(date_received_max="2017-04-14")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -589,7 +606,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_company_received_min__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company_received_min__valid")
         res = search(company_received_min="2014-04-14")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -614,7 +632,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_company_received_max__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company_received_max__valid")
         res = search(company_received_max="2017-04-14")
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -639,7 +658,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_company__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company__valid")
         res = search(company=["Bank 1", "Second Bank"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -657,7 +677,6 @@ class EsInterfaceTest_Search(TestCase):
         mock_scroll.assert_not_called()
         self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
-
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._get_meta")
     @mock.patch.object(Elasticsearch, 'search')
@@ -666,9 +685,11 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_company_agg_exclude__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company_agg_exclude__valid")
-        res = search(agg_exclude=['company'], company=["Bank 1", "Second Bank"])
+        res = search(agg_exclude=['company'], company=[
+                     "Bank 1", "Second Bank"])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -693,7 +714,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_product__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_product__valid")
         res = search(product=["Payday Loan", u"Mortgage\u2022FHA mortgage"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -719,10 +741,11 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_issue__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_issue__valid")
         res = search(issue=[u"Communication tactics\u2022Frequent or repeated calls",
-        "Loan servicing, payments, escrow account"])
+                            "Loan servicing, payments, escrow account"])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -746,7 +769,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_state__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_state__valid")
         res = search(state=["CA", "VA", "OR"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -772,7 +796,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_zip_code__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_zip_code__valid")
         res = search(zip_code=["12345", "23435", "03433"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -791,7 +816,6 @@ class EsInterfaceTest_Search(TestCase):
         mock_scroll.assert_not_called()
         self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
-
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._get_meta")
     @mock.patch.object(Elasticsearch, 'search')
@@ -800,9 +824,11 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_zip_code_agg_exclude__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_zip_code_agg_exclude__valid")
-        res = search(agg_exclude=['zip_code'], zip_code=["12345", "23435", "03433"])
+        res = search(agg_exclude=['zip_code'], zip_code=[
+                     "12345", "23435", "03433"])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -827,7 +853,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_timely__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_timely__valid")
         res = search(timely=["Yes", "No"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -853,9 +880,11 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_company_response__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company_response__valid")
-        res = search(company_response=["Closed", "Closed with non-monetary relief"])
+        res = search(company_response=[
+                     "Closed", "Closed with non-monetary relief"])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -879,9 +908,11 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_company_public_response__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company_public_response__valid")
-        res = search(company_public_response=["Company chooses not to provide a public response", "Company believes it acted appropriately as authorized by contract or law"])
+        res = search(company_public_response=["Company chooses not to provide a public response",
+                                              "Company believes it acted appropriately as authorized by contract or law"])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -905,7 +936,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_consumer_consent_provided__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_consumer_consent_provided__valid")
         res = search(consumer_consent_provided=["Consent provided"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -931,7 +963,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_submitted_via__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_submitted_via__valid")
         res = search(submitted_via=["Web"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -957,7 +990,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_tags__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_tags__valid")
         res = search(tags=["Older American", "Servicemember"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -983,7 +1017,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_has_narrative__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_has_narrative__valid")
         res = search(has_narrative=["true"])
         self.assertEqual(1, len(mock_search.call_args_list))
@@ -1010,7 +1045,8 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_no_highlight__valid(self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
         body = load("search_no_highlight__valid")
         res = search(no_highlight=True)
@@ -1031,6 +1067,7 @@ class EsInterfaceTest_Search(TestCase):
 
 
 class EsInterfaceTest_Suggest(TestCase):
+
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch.object(Elasticsearch, 'suggest')
     def test_suggest_with_no_param__valid(self, mock_suggest):
@@ -1074,7 +1111,8 @@ class EsInterfaceTest_Suggest(TestCase):
                 }
             ]
         }
-        body = {"sgg": {"text": "Mortgage", "completion": {"field": "suggest", "size": 6}}}
+        body = {"sgg": {"text": "Mortgage", "completion": {
+            "field": "suggest", "size": 6}}}
         res = suggest(text="Mortgage")
         self.assertEqual(len(mock_suggest.call_args), 2)
         self.assertEqual(0, len(mock_suggest.call_args[0]))
@@ -1103,7 +1141,8 @@ class EsInterfaceTest_Suggest(TestCase):
                 }
             ]
         }
-        body = {"sgg": {"text": "Loan", "completion": {"field": "suggest", "size": 10}}}
+        body = {"sgg": {"text": "Loan", "completion": {
+            "field": "suggest", "size": 10}}}
         res = suggest(text="Loan", size=10)
         self.assertEqual(len(mock_suggest.call_args), 2)
         self.assertEqual(0, len(mock_suggest.call_args[0]))
@@ -1115,6 +1154,7 @@ class EsInterfaceTest_Suggest(TestCase):
 
 
 class EsInterfaceTest_FilterSuggest(TestCase):
+
     def setUp(self):
         self.body = {'foo': 'bar'}
         self.oneAgg = {
@@ -1167,7 +1207,8 @@ class EsInterfaceTest_FilterSuggest(TestCase):
         }
         mock_builder2.return_value = agg
 
-        actual = filter_suggest('company.suggest', display_field='company.raw', text='BA')
+        actual = filter_suggest(
+            'company.suggest', display_field='company.raw', text='BA')
 
         mock_search.assert_called_once_with(
             body={
@@ -1191,7 +1232,7 @@ class EsInterfaceTest_FilterSuggest(TestCase):
                             }
                         }
                     }
-               }
+                }
             },
             doc_type='DOCTYPE',
             index='INDEX')
@@ -1221,7 +1262,7 @@ class EsInterfaceTest_FilterSuggest(TestCase):
                     {"key": "208XX", "doc_count": 775},
                     {"key": "206XX", "doc_count": 405}
                 ]}}
- 
+
         mock_search.return_value = result
         mock_builder1.return_value = self.body
         agg = copy.deepcopy(self.oneAgg)
@@ -1259,7 +1300,7 @@ class EsInterfaceTest_FilterSuggest(TestCase):
                             }
                         }
                     }
-               }
+                }
             },
             doc_type='DOCTYPE',
             index='INDEX')
@@ -1267,7 +1308,10 @@ class EsInterfaceTest_FilterSuggest(TestCase):
         self.assertEqual(actual, [
             '207XX', '200XX', '201XX', '208XX', '206XX'
         ])
+
+
 class EsInterfaceTest_Document(TestCase):
+
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE", "DOC_TYPE")
     @mock.patch.object(Elasticsearch, 'search')

--- a/complaint_search/tests/test_stream_content.py
+++ b/complaint_search/tests/test_stream_content.py
@@ -4,54 +4,55 @@ from complaint_search.stream_content import (
     StreamJSONContent,
 )
 
+
 class StreamCSVContentTests(TestCase):
 
     def setUp(self):
         pass
 
     def test_iter(self):
-        sc = StreamCSVContent(None, iter([1,2,3]))
+        sc = StreamCSVContent(None, iter([1, 2, 3]))
         self.assertTrue(isinstance(iter(sc), StreamCSVContent))
 
     def test_next_no_header(self):
-        sc = StreamCSVContent(None, iter([1,2,3]))
-        content = [ item for item in sc ]
-        self.assertListEqual([1,2,3], content)
-
+        sc = StreamCSVContent(None, iter([1, 2, 3]))
+        content = [item for item in sc]
+        self.assertListEqual([1, 2, 3], content)
 
     def test_next_header(self):
-        sc = StreamCSVContent("header", iter([1,2,3]))
-        content = [ item for item in sc ]
-        self.assertListEqual(["header",1,2,3], content)
+        sc = StreamCSVContent("header", iter([1, 2, 3]))
+        content = [item for item in sc]
+        self.assertListEqual(["header", 1, 2, 3], content)
+
 
 class StreamJSONContentTests(TestCase):
 
     def setUp(self):
         self.content = '{"index": {"_index": "test", "_id": 12345}}\n' \
-        '{"product": "mortgage", "complaint_id": 12345, "tags": null}\n' \
-        '{"index": {"_index": "test", "_id": 23456}}\n' \
-        '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"}\n' \
-        '{"index": {"_index": "test", "_id": 45678}}\n' \
-        '{"product": "loan", "complaint_id": 45678, "tags": null} \n' \
+            '{"product": "mortgage", "complaint_id": 12345, "tags": null}\n' \
+            '{"index": {"_index": "test", "_id": 23456}}\n' \
+            '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"}\n' \
+            '{"index": {"_index": "test", "_id": 45678}}\n' \
+            '{"product": "loan", "complaint_id": 45678, "tags": null} \n' \
 
         # pretend this is broken up randomly every 20 chars
-        self.content_list = [ self.content[(i*20):(i*20+20)]
-            for i in range(len(self.content) / 20 + 1) ]
+        self.content_list = [self.content[(i * 20):(i * 20 + 20)]
+                             for i in range(len(self.content) / 20 + 1)]
 
     def test_iter(self):
         sc = StreamJSONContent(iter(self.content_list))
         self.assertTrue(isinstance(iter(sc), StreamJSONContent))
 
     def test_next_complete(self):
-        for size in range(1,1024):
-            content_list = [ self.content[(i*size):(i*size+size)]
-                for i in range(len(self.content) / size + 1) ]
+        for size in range(1, 1024):
+            content_list = [self.content[(i * size):(i * size + size)]
+                            for i in range(len(self.content) / size + 1)]
             sc = StreamJSONContent(iter(content_list))
             result = ""
             for json_in_progress in sc:
                 result += json_in_progress
 
             exp_result = '[{"product": "mortgage", "complaint_id": 12345, "tags": null},' \
-            '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"},' \
-            '{"product": "loan", "complaint_id": 45678, "tags": null}]'
+                '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"},' \
+                '{"product": "loan", "complaint_id": 45678, "tags": null}]'
             self.assertEqual(exp_result, result)

--- a/complaint_search/tests/test_stream_content.py
+++ b/complaint_search/tests/test_stream_content.py
@@ -1,5 +1,8 @@
 from django.test import TestCase
-from complaint_search.stream_content import StreamContent
+from complaint_search.stream_content import (
+    StreamCSVContent,
+    StreamJSONContent,
+)
 
 class StreamContentTests(TestCase):
 
@@ -7,16 +10,16 @@ class StreamContentTests(TestCase):
         pass
 
     def test_iter(self):
-        sc = StreamContent(None, iter([1,2,3]))
-        self.assertTrue(isinstance(iter(sc), StreamContent))
+        sc = StreamCSVContent(None, iter([1,2,3]))
+        self.assertTrue(isinstance(iter(sc), StreamCSVContent))
 
     def test_next_no_header(self):
-        sc = StreamContent(None, iter([1,2,3]))
+        sc = StreamCSVContent(None, iter([1,2,3]))
         content = [ item for item in sc ]
         self.assertListEqual([1,2,3], content)
 
 
     def test_next_header(self):
-        sc = StreamContent("header", iter([1,2,3]))
+        sc = StreamCSVContent("header", iter([1,2,3]))
         content = [ item for item in sc ]
         self.assertListEqual(["header",1,2,3], content)

--- a/complaint_search/tests/test_stream_content.py
+++ b/complaint_search/tests/test_stream_content.py
@@ -4,7 +4,7 @@ from complaint_search.stream_content import (
     StreamJSONContent,
 )
 
-class StreamContentTests(TestCase):
+class StreamCSVContentTests(TestCase):
 
     def setUp(self):
         pass
@@ -23,3 +23,35 @@ class StreamContentTests(TestCase):
         sc = StreamCSVContent("header", iter([1,2,3]))
         content = [ item for item in sc ]
         self.assertListEqual(["header",1,2,3], content)
+
+class StreamJSONContentTests(TestCase):
+
+    def setUp(self):
+        self.content = '{"index": {"_index": "test", "_id": 12345}}\n' \
+        '{"product": "mortgage", "complaint_id": 12345, "tags": null}\n' \
+        '{"index": {"_index": "test", "_id": 23456}}\n' \
+        '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"}\n' \
+        '{"index": {"_index": "test", "_id": 45678}}\n' \
+        '{"product": "loan", "complaint_id": 45678, "tags": null} \n' \
+
+        # pretend this is broken up randomly every 20 chars
+        self.content_list = [ self.content[(i*20):(i*20+20)]
+            for i in range(len(self.content) / 20 + 1) ]
+
+    def test_iter(self):
+        sc = StreamJSONContent(iter(self.content_list))
+        self.assertTrue(isinstance(iter(sc), StreamJSONContent))
+
+    def test_next_complete(self):
+        for size in range(1,1024):
+            content_list = [ self.content[(i*size):(i*size+size)]
+                for i in range(len(self.content) / size + 1) ]
+            sc = StreamJSONContent(iter(content_list))
+            result = ""
+            for json_in_progress in sc:
+                result += json_in_progress
+
+            exp_result = '[{"product": "mortgage", "complaint_id": 12345, "tags": null},' \
+            '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"},' \
+            '{"product": "loan", "complaint_id": 45678, "tags": null}]'
+            self.assertEqual(exp_result, result)

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -130,7 +130,7 @@ def search(request):
         return Response(
             serializer.errors, status=status.HTTP_400_BAD_REQUEST
         )
- 
+
     results = es_interface.search(
         agg_exclude=AGG_EXCLUDE_FIELDS, **serializer.validated_data)
     headers = _buildHeaders()
@@ -155,6 +155,7 @@ def search(request):
 
     return response
 
+
 @api_view(['GET'])
 @catch_es_error
 def suggest(request):
@@ -167,6 +168,7 @@ def suggest(request):
     else:
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
 def _suggest_field(data, field, display_field=None):
     serializer = SuggestFilterInputSerializer(data=data)
     if serializer.is_valid():
@@ -176,6 +178,7 @@ def _suggest_field(data, field, display_field=None):
         return Response(results, headers=_buildHeaders())
     else:
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
 
 @api_view(['GET'])
 @catch_es_error
@@ -188,6 +191,7 @@ def suggest_zip(request):
         data['text'] = data['text'].upper()
     return _suggest_field(data, 'zip_code')
 
+
 @api_view(['GET'])
 @catch_es_error
 def suggest_company(request):
@@ -198,6 +202,7 @@ def suggest_company(request):
     if data.get('text'):
         data['text'] = data['text'].upper()
     return _suggest_field(data, 'company.suggest', 'company.raw')
+
 
 @api_view(['GET'])
 @throttle_classes([DocumentAnonRateThrottle, ])


### PR DESCRIPTION
Data format plugin returns JSON in elasticsearch bulk format, this is not desirable format.  The format should be like a list of complaints without unnecessary information.

## Additions:
- Added an iterator to strip out unnecessary index json prefixed the complaint json, and added a comma to separate them, as well as the square bracket to create a list
