### PR TITLE
Remove last_updated timezone

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -76,11 +76,21 @@ def _get_meta():
         # size: 0 here to prevent taking too long since we only needed max_date
         "size": 0,
         "aggs": {
-            "max_date": {"max": {"field": "date_received"}},
+            "max_date": {
+                "max": {
+                    "field": "date_received",
+                    "format": "yyyy-MM-dd'T'HH:mm:ss"
+                }
+            },
             "max_narratives": {
                 "filter": {"term": {"has_narrative": "true"}},
                 "aggs": {
-                    "max_date": {"max": {"field": ":updated_at"}}
+                    "max_date": {
+                        "max": {
+                            "field": ":updated_at",
+                            "format": "yyyy-MM-dd'T'HH:mm:ss"
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The original format Elasticsearch returns a datetime that includes a Z to indicate timezone.  This Z creates an incorrect time when pass into other tools.  Removing the Z by giving a specific format the datetime should return as.

## Additions:
- Specified date format for max_date/max_narrative