### PR TITLE
Remove company param in own type-ahead suggester

### DIFF
--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -1234,7 +1234,8 @@ class EsInterfaceTest_FilterSuggest(TestCase):
                     {"key": "Bank 2", "doc_count": 1123},
                     {"key": "BANK 3rd", "doc_count": 810},
                     {"key": "bank 4", "doc_count": 775},
-                    {"key": "BANK 5th", "doc_count": 405}
+                    {"key": "BANK 5th", "doc_count": 405},
+                    {"key": "company 1", "doc_count": 12}
                 ]}}
         mock_search.return_value = result
         mock_builder1.return_value = self.body
@@ -1250,7 +1251,7 @@ class EsInterfaceTest_FilterSuggest(TestCase):
         mock_builder2.return_value = agg
 
         actual = filter_suggest(
-            'company.suggest', display_field='company.raw', text='BA')
+            'company.suggest', display_field='company.raw', text='BA', company='company 1')
 
         mock_search.assert_called_once_with(
             body={
@@ -1280,7 +1281,7 @@ class EsInterfaceTest_FilterSuggest(TestCase):
             index='INDEX')
         mock_builder2.assert_called_once_with('company.suggest')
         self.assertEqual(actual, [
-            'bank 1', 'Bank 2', 'BANK 3rd', 'bank 4', 'BANK 5th'
+            'bank 1', 'Bank 2', 'BANK 3rd', 'bank 4', 'BANK 5th', 'company 1'
         ])
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")

--- a/complaint_search/tests/test_views_suggest_company.py
+++ b/complaint_search/tests/test_views_suggest_company.py
@@ -1,0 +1,78 @@
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from elasticsearch import TransportError
+import mock
+from complaint_search.es_interface import filter_suggest
+
+
+class SuggestCompanyTests(APITestCase):
+
+    def setUp(self):
+        pass
+
+    @mock.patch('complaint_search.es_interface.filter_suggest')
+    def test_suggest_no_param(self, mock_essuggest):
+        """
+        Suggesting with no parameters
+        """
+        url = reverse('complaint_search:suggest_company')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_essuggest.assert_not_called()
+        self.assertDictEqual(
+            {'text': [u'This field is required.']},
+            response.data)
+
+    @mock.patch('complaint_search.es_interface.filter_suggest')
+    def test_suggest_text__valid(self, mock_essuggest):
+        """
+        Suggesting with text
+        """
+        url = reverse('complaint_search:suggest_company')
+        param = {"text": "ban", "company": "company 1"}
+        mock_essuggest.return_value = 'OK'
+        response = self.client.get(url, param)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_essuggest.assert_called_once_with(
+            'company.suggest',
+            'company.raw',
+            field='complaint_what_happened',
+            format='default',
+            frm=0,
+            no_aggs=False,
+            no_highlight=False,
+            size=10,
+            sort='relevance_desc',
+            text=u'BAN'
+        )
+        self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.filter_suggest')
+    def test_suggest_cors_headers(self, mock_essuggest):
+        """
+        Make sure the response has CORS headers in debug mode
+        """
+        settings.DEBUG = True
+        url = reverse('complaint_search:suggest_company')
+        param = {"text": "com"}
+        mock_essuggest.return_value = 'OK'
+        response = self.client.get(url, param)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
+
+
+    @mock.patch('complaint_search.es_interface.filter_suggest')
+    def test_suggest__transport_error_without_status_code(
+        self, mock_essuggest
+    ):
+        mock_essuggest.side_effect = TransportError('N/A', "Error")
+        url = reverse('complaint_search:suggest_zip')
+        param = {"text": "test"}
+        response = self.client.get(url, param)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            {"error": "Elasticsearch error: Error"}, response.data
+        )
+

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -195,12 +195,24 @@ def suggest_zip(request):
 @api_view(['GET'])
 @catch_es_error
 def suggest_company(request):
+    
+    def removekey(d, key):
+        r = dict(d)
+        del r[key]
+        return r
+
     validVars = list(QPARAMS_VARS)
     validVars.append('text')
 
     data = _parse_query_params(request.query_params, validVars)
+    
+    # Company filters to date should not be applied to return params
+    if 'company' in data:
+        data = removekey(data, 'company')
+
     if data.get('text'):
         data['text'] = data['text'].upper()
+    
     return _suggest_field(data, 'company.suggest', 'company.raw')
 
 

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -196,6 +196,7 @@ def suggest_zip(request):
 @catch_es_error
 def suggest_company(request):
     
+    # Key removal that takes mutation into account in case of other reference
     def removekey(d, key):
         r = dict(d)
         del r[key]
@@ -206,7 +207,7 @@ def suggest_company(request):
 
     data = _parse_query_params(request.query_params, validVars)
     
-    # Company filters to date should not be applied to return params
+    # Company filters should not be applied to their own aggregation filter
     if 'company' in data:
         data = removekey(data, 'company')
 


### PR DESCRIPTION
Company was being passed as a filter parameter to the company type-ahead suggester. 

Because of this, once a user selected a single company no other companies were available to the suggester because they were being filtered.

This code removes the parameter if it exists, but continues to apply other field parameters so type-ahead functions similar to the surrounding filters and returns similar content.

This issue does not seem to impact the similar zip code suggester - I think this is due to the fields being returned and how they are matched but I am not 100% sure.