### PR TITLE
Add a workaround for requests.get/NO_PROXY

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -187,7 +187,13 @@ def search(agg_exclude=None, **kwargs):
 
         url = "{}/{}/{}/_data?{}".format(_ES_URL, _COMPLAINT_ES_INDEX,
                                          _COMPLAINT_DOC_TYPE, p)
-        response = requests.get(url, auth=(
+
+        # requests.get does not seem to respect an IP address in NO_PROXY.
+        # This is a workaround based on:
+        # https://stackoverflow.com/questions/28521535/requests-how-to-disable-bypass-proxy/28521696#28521696  # noqa
+        session = requests.Session()
+        session.trust_env = False
+        response = session.get(url, auth=(
             _ES_USER, _ES_PASSWORD), stream=True)
         if response.ok:
             res = response.iter_content(chunk_size=CHUNK_SIZE)

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -212,7 +212,7 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE", "DOC_TYPE")
     @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch('requests.get')
+    @mock.patch('requests.Session.get')
     @mock.patch('json.dumps')
     @mock.patch('urllib.urlencode')
     def test_search_with_format_json__valid(self, mock_urlencode,
@@ -260,7 +260,7 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE", "DOC_TYPE")
     @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch('requests.get')
+    @mock.patch('requests.Session.get')
     @mock.patch('json.dumps')
     @mock.patch('urllib.urlencode')
     def test_search_with_format_csv__valid(self, mock_urlencode, mock_jdump, mock_rget, mock_search):


### PR DESCRIPTION
This PR adds a work around developed this morning with @sephcoster and @rosskarchner for `requests.get` seeming not to respect the `NO_PROXY` environment variable for IP addresses. 

That `requests.get` was trying to use a proxy to reach the Elasticsearch server was causing this query to hang.