### PR TITLE
Allow more characters when suggest searching

### DIFF
--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -129,4 +129,4 @@ class SuggestInputSerializer(serializers.Serializer):
 
 
 class SuggestFilterInputSerializer(SearchInputSerializer):
-    text = serializers.CharField(max_length=10, required=True)
+    text = serializers.CharField(max_length=100, required=True)


### PR DESCRIPTION
## Error

When a user types more than 10 characters into type-ahead the suggest API returns a 400 error "must contain less than 10 characters"

This happens for users when they select values in Company Name type-aheads. 

Steps to duplicate:
1) /data-research/consumer-complaints/search
2) Select "Company Name" from search drop-down
3) Type "BOK FINAN" and select "BOK FINANCIAL GROUP"
4) After results displayed, the search bar automatically returns "there was an issue retrieving options" which makes the user think there was a problem with their search.

## Fix

Increased the number of characters allowed

![screen shot 2017-11-13 at 11 53 00 am](https://user-images.githubusercontent.com/8754176/32739572-43a165d6-c86e-11e7-89fe-60fd2b56b52a.png)
