### PR TITLE
Narrative Max Aggregations

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -112,7 +112,7 @@ def _get_meta():
         "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
         "last_indexed": max_date_res["aggregations"]["max_indexed_date"]["value_as_string"],
         "total_record_count": count_res["count"],
-        "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"]),
+        "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_date"]["value_as_string"]),
         "is_narrative_stale": _is_data_stale(from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"])),
         "has_data_issue": flag_enabled('CCDB_TECHNICAL_ISSUES')
     }

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -68,6 +68,7 @@ def _is_data_stale(last_updated_time):
 
 
 def from_timestamp(seconds):
+    # Socrata fields (:field_name) are indexed in seconds, not the usual milliseconds
     fromtimestamp = datetime.fromtimestamp(seconds)
     return fromtimestamp.strftime('%Y-%m-%d')
 
@@ -96,7 +97,6 @@ def _get_meta():
                     "max_date": {
                         "max": {
                             "field": ":updated_at",
-                            "format": "yyyy-MM-dd'T'12:00:00-05:00"
                         }
                     }
                 }
@@ -104,16 +104,16 @@ def _get_meta():
         }
     }
     max_date_res = _get_es().search(index=_COMPLAINT_ES_INDEX, body=body)
-    count_res = _get_es().count(index=_COMPLAINT_ES_INDEX, doc_type=_COMPLAINT_DOC_TYPE)
-    down_res = _is_data_stale(max_date_res["aggregations"][
-                              "max_date"]["value_as_string"])
+    count_res = _get_es().count(index=_COMPLAINT_ES_INDEX, 
+        doc_type=_COMPLAINT_DOC_TYPE)
 
     result = {
         "license": "CC0",
         "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
         "last_indexed": max_date_res["aggregations"]["max_indexed_date"]["value_as_string"],
         "total_record_count": count_res["count"],
-        "is_data_stale": _is_data_stale(from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"])),
+        "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"]),
+        "is_narrative_stale": _is_data_stale(from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"])),
         "has_data_issue": flag_enabled('CCDB_TECHNICAL_ISSUES')
     }
 

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -69,8 +69,7 @@ class EsInterfaceTest_Search(TestCase):
         {
             "aggregations": {
                 "max_date": {
-                    "value_as_string": "2017-01-01",
-                    "value": 1483280000000.0
+                    "value_as_string": "2017-01-01"
                 },
                 "max_indexed_date": {
                     "value_as_string": "2017-01-02"

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -6,7 +6,6 @@ from complaint_search.es_interface import (
     _ES_USER,
     _ES_PASSWORD,
     _get_meta,
-    _get_now,
     search,
     suggest,
     filter_suggest,

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -6,6 +6,7 @@ from complaint_search.es_interface import (
     _ES_USER,
     _ES_PASSWORD,
     _get_meta,
+    _get_now,
     search,
     suggest,
     filter_suggest,
@@ -68,14 +69,16 @@ class EsInterfaceTest_Search(TestCase):
         {
             "aggregations": {
                 "max_date": {
-                    "value_as_string": "2017-01-01"
+                    "value_as_string": "2017-01-01",
+                    "value": 1483280000000.0
                 },
                 "max_indexed_date": {
                     "value_as_string": "2017-01-02"
                 },
                 "max_narratives": {
                     "max_date": {
-                        "value": 1507011188.0
+                        "value": 1483400000.0
+                        # 150970000.0 for November 3rd 2017
                     }
                 }
             }
@@ -96,6 +99,7 @@ class EsInterfaceTest_Search(TestCase):
             'last_updated': '2017-01-01',
             'license': 'CC0',
             'is_data_stale': False,
+            'is_narrative_stale': False,
             'has_data_issue': False,
         }
     }
@@ -135,6 +139,7 @@ class EsInterfaceTest_Search(TestCase):
         res = _get_meta()
         exp_res = copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
         exp_res['is_data_stale'] = True
+        exp_res['is_narrative_stale'] = True
         self.assertDictEqual(exp_res, res)
 
     @mock.patch("complaint_search.es_interface._get_now")


### PR DESCRIPTION
Tuned the Narrative Max aggregation to separate out narrative  max date from date and provide as metadata for each request:
- `is_narrative_stale`
- `is_data_stale`

Warnings taking effect will require CCDB5-UI pull request to be merged.