### PR TITLE
fix title of docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: ccdb5-api
+site_name: Consumer complaint search API
 pages:
 - Documentation: index.md
 

--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -26,8 +26,6 @@ paths:
       produces:
       - "application/json"
       - "text/csv"
-      - "application/vnd.ms-excel"
-      - "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
       parameters:
       - $ref: "#/parameters/search_term"
       - $ref: "#/parameters/field"
@@ -458,8 +456,6 @@ parameters:
     enum:
     - "json"
     - "csv"
-    - "xls"
-    - "xlsx"
     default: "json"
   from:
     name: frm


### PR DESCRIPTION
This is just catching up on a couple fixes I made en route to getting the docs to render.
- Gives the docs page a better title
- Removes references to deprecated excel download options

There should be no need to re-deploy docs.