### PR TITLE
Use abstract spec for dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,27 +9,16 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-def parse_requirements():
-    """Return abstract requirements (without version numbers)
-    from requirements.txt.
-    As an exception, requirements that are URLs are used as-is.
-    This is tested to be compatible with pip 9.0.1.
-    Background: https://stackoverflow.com/a/42033122/
-    """
+install_requires = [
+    'Django>=1.8,<1.9',
+    'djangorestframework>=3.1,<3.2',
+    'elasticsearch>=2.4.1,<3',
+    'requests>=2.14,<2.15',
+    'urllib3>=1.21,<1.22',
+    'django-localflavor>=1.5,<1.6',
+    'wagtail-flags>=2.0.5,<2.2'
+]
 
-    path = os.path.join(os.path.dirname(__file__), 'requirements.txt')
-    requirements = pip.req.parse_requirements(
-        path, session=pip.download.PipSession()
-    )
-    requirements = [
-        req.name or req.link.url
-        for req in requirements
-        if 'git+' not in (req.name or req.link.url)
-    ]
-    return requirements
-
-
-install_requires = parse_requirements()
 
 setup(
     name='ccdb5-api',


### PR DESCRIPTION
`pip.req.parse_requirements` is not available in pip 10, so this package breaks when attempting to install it with pip 10 (discovered this trying to run cfgov-refresh's `tox -e validate-assets`). This change also makes the logical distinction between the abstract dependencies in setup.py and the concrete dependencies in requirements.txt.

I believe these to be reasonable version ranges based on what we have in cfgov-refresh already, what's specified in requirements.txt, and the changelog for each of the dependencies.