### PR TITLE
Improve error handling

### DIFF
--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -2,15 +2,15 @@ from rest_framework import status
 from rest_framework.response import Response
 from elasticsearch import TransportError
 
+
 def catch_es_error(function):
     def wrap(request, *args, **kwargs):
         try:
             return function(request, *args, **kwargs)
         except TransportError as e:
-            status_code = e.status_code if isinstance(e.status_code, int) \
-                else status.HTTP_400_BAD_REQUEST
+            status_code = 424  # HTTP_424_FAILED_DEPENDENCY
             res = {
-                "error": 'Elasticsearch error: ' + e.error
+                "error": 'There was an error searching Elasticsearch'
             }
             return Response(res, status=status_code)
     wrap.__doc__ = function.__doc__

--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -1,13 +1,18 @@
+import logging
 from rest_framework import status
 from rest_framework.response import Response
 from elasticsearch import TransportError
+
+log = logging.getLogger(__name__)
 
 
 def catch_es_error(function):
     def wrap(request, *args, **kwargs):
         try:
             return function(request, *args, **kwargs)
-        except TransportError as e:
+        except TransportError as te:
+            log.error(te)
+
             status_code = 424  # HTTP_424_FAILED_DEPENDENCY
             res = {
                 "error": 'There was an error calling Elasticsearch'

--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -18,6 +18,14 @@ def catch_es_error(function):
                 "error": 'There was an error calling Elasticsearch'
             }
             return Response(res, status=status_code)
+        except Exception as e:
+            log.error(e)
+
+            status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            res = {
+                "error": 'There was a problem retrieving your request'
+            }
+            return Response(res, status=status_code)
     wrap.__doc__ = function.__doc__
     wrap.__name__ = function.__name__
     return wrap

--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -10,7 +10,7 @@ def catch_es_error(function):
         except TransportError as e:
             status_code = 424  # HTTP_424_FAILED_DEPENDENCY
             res = {
-                "error": 'There was an error searching Elasticsearch'
+                "error": 'There was an error calling Elasticsearch'
             }
             return Response(res, status=status_code)
     wrap.__doc__ = function.__doc__

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -162,7 +162,7 @@ def search(agg_exclude=None, **kwargs):
     )
 
     # format
-    res = None
+    res = {}
     format = params.get("format")
     if format == "default":
         if not params.get("no_aggs"):

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -375,7 +375,7 @@ class EsInterfaceTest_Search(TestCase):
     def test_search_with_format__invalid(self, mock_rget, mock_search):
         mock_search.return_value = 'OK'
         res = search(format="pdf")
-        self.assertIsNone(res)
+        self.assertEqual(res, {})
         mock_search.assert_not_called()
         mock_rget.assert_not_called()
 

--- a/complaint_search/tests/test_view_suggest_company.py
+++ b/complaint_search/tests/test_view_suggest_company.py
@@ -63,27 +63,14 @@ class SuggestCompanyTests(APITestCase):
         self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
 
     @mock.patch('complaint_search.es_interface.filter_suggest')
-    def test_suggest__transport_error_with_status_code(self, mock_essuggest):
-        mock_essuggest.side_effect = TransportError(
-            status.HTTP_404_NOT_FOUND, "Error"
-        )
-        url = reverse('complaint_search:suggest_company')
-        param = {"text": "test"}
-        response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertDictEqual(
-            {"error": "Elasticsearch error: Error"}, response.data
-        )
-
-    @mock.patch('complaint_search.es_interface.filter_suggest')
-    def test_suggest__transport_error_without_status_code(
+    def test_suggest__transport_error(
         self, mock_essuggest
     ):
         mock_essuggest.side_effect = TransportError('N/A', "Error")
         url = reverse('complaint_search:suggest_company')
         param = {"text": "test"}
         response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "Elasticsearch error: Error"}, response.data
+            {"error": "There was an error searching Elasticsearch"}, response.data
         )

--- a/complaint_search/tests/test_view_suggest_company.py
+++ b/complaint_search/tests/test_view_suggest_company.py
@@ -72,5 +72,6 @@ class SuggestCompanyTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error searching Elasticsearch"}, response.data
+            {"error": "There was an error calling Elasticsearch"},
+            response.data
         )

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -11,6 +11,7 @@ from complaint_search.throttling import (
     _CCDB_UI_URL,
 )
 
+
 class DocumentTests(APITestCase):
 
     def setUp(self):
@@ -34,7 +35,6 @@ class DocumentTests(APITestCase):
         mock_esdocument.assert_called_once_with("123456")
         self.assertEqual('OK', response.data)
 
-
     @mock.patch('complaint_search.es_interface.document')
     def test_document_with_document_anon_rate_throttle(self, mock_esdocument):
         url = reverse('complaint_search:complaint', kwargs={"id": "123456"})
@@ -47,7 +47,9 @@ class DocumentTests(APITestCase):
             self.assertEqual('OK', response.data)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(
+            response.status_code, status.HTTP_429_TOO_MANY_REQUESTS
+        )
         self.assertIsNotNone(response.data.get('detail'))
         self.assertIn("Request was throttled", response.data.get('detail'))
         self.assertEqual(limit, mock_esdocument.call_count)
@@ -77,4 +79,7 @@ class DocumentTests(APITestCase):
         url = reverse('complaint_search:complaint', kwargs={"id": "123456"})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 424)
-        self.assertDictEqual({"error": "There was an error searching Elasticsearch"}, response.data)
+        self.assertDictEqual(
+            {"error": "There was an error calling Elasticsearch"},
+            response.data
+        )

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -72,19 +72,9 @@ class DocumentTests(APITestCase):
         self.assertEqual(5, limit)
 
     @mock.patch('complaint_search.es_interface.document')
-    def test_document__transport_error_with_status_code(self, mock_esdocument):
-        mock_esdocument.side_effect = TransportError(status.HTTP_404_NOT_FOUND, "Error")
-        url = reverse('complaint_search:complaint', kwargs={"id": "123456"})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
-
-    @mock.patch('complaint_search.es_interface.document')
-    def test_document__transport_error_without_status_code(self, mock_esdocument):
+    def test_document__transport_error(self, mock_esdocument):
         mock_esdocument.side_effect = TransportError('N/A', "Error")
         url = reverse('complaint_search:complaint', kwargs={"id": "123456"})
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
-
-
+        self.assertEqual(response.status_code, 424)
+        self.assertDictEqual({"error": "There was an error searching Elasticsearch"}, response.data)

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -666,17 +666,9 @@ class SearchTests(APITestCase):
         self.assertEqual(6, limit)
 
     @mock.patch('complaint_search.es_interface.search')
-    def test_search__transport_error_with_status_code(self, mock_essearch):
-        mock_essearch.side_effect = TransportError(status.HTTP_404_NOT_FOUND, "Error")
-        url = reverse('complaint_search:search')
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
-
-    @mock.patch('complaint_search.es_interface.search')
-    def test_search__transport_error_without_status_code(self, mock_essearch):
+    def test_search__transport_error(self, mock_essearch):
         mock_essearch.side_effect = TransportError('N/A', "Error")
         url = reverse('complaint_search:search')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
+        self.assertEqual(response.status_code, 424)
+        self.assertDictEqual({"error": "There was an error searching Elasticsearch"}, response.data)

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -675,3 +675,14 @@ class SearchTests(APITestCase):
             {"error": "There was an error calling Elasticsearch"},
             response.data
         )
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search__big_error(self, mock_essearch):
+        mock_essearch.side_effect = MemoryError("Out of memory")
+        url = reverse('complaint_search:search')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 500)
+        self.assertDictEqual(
+            {"error": "There was a problem retrieving your request"},
+            response.data
+        )

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -671,4 +671,7 @@ class SearchTests(APITestCase):
         url = reverse('complaint_search:search')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 424)
-        self.assertDictEqual({"error": "There was an error searching Elasticsearch"}, response.data)
+        self.assertDictEqual(
+            {"error": "There was an error calling Elasticsearch"},
+            response.data
+        )

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -10,7 +10,7 @@ import mock
 from datetime import date, datetime
 from elasticsearch import TransportError
 from complaint_search.defaults import (
-    FORMAT_CONTENT_TYPE_MAP, 
+    FORMAT_CONTENT_TYPE_MAP,
     PARAMS,
 )
 from complaint_search.es_interface import search
@@ -57,7 +57,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({}))
         self.assertEqual('OK', response.data)
 
@@ -102,7 +102,7 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(agg_exclude=self.buildDefaultAggExclude(), 
+        calls = [ mock.call(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "field": SearchInputSerializer.FIELD_MAP.get(field_pair[0],
                 field_pair[0])}))
@@ -127,7 +127,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
@@ -138,7 +138,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
@@ -162,7 +162,7 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"size": ["Ensure this value is greater than or equal to 0."]}, 
+            {"size": ["Ensure this value is greater than or equal to 0."]},
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -174,7 +174,7 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"size": ["Ensure this value is less than or equal to 10000000."]}, 
+            {"size": ["Ensure this value is less than or equal to 10000000."]},
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -184,7 +184,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
@@ -220,7 +220,7 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"frm": ["Ensure this value is less than or equal to 10000000."]}, 
+            {"frm": ["Ensure this value is less than or equal to 10000000."]},
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')
@@ -245,7 +245,7 @@ class SearchTests(APITestCase):
             self.assertEqual(status.HTTP_200_OK, response.status_code)
             self.assertEqual('OK', response.data)
 
-        calls = [ mock.call(agg_exclude=self.buildDefaultAggExclude(), 
+        calls = [ mock.call(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({"sort": sort_pair[0]}))
             for sort_pair in SearchInputSerializer.SORT_CHOICES ]
         mock_essearch.assert_has_calls(calls)
@@ -268,7 +268,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams(params))
         self.assertEqual('OK', response.data)
 
@@ -279,7 +279,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "date_received_min": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
@@ -302,7 +302,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "date_received_max": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
@@ -325,7 +325,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "company_received_min": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
@@ -348,7 +348,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "company_received_max": date(2017, 4, 11)}))
         self.assertEqual('OK', response.data)
@@ -371,7 +371,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "company": ["One Bank", "Bank 2"]}))
         self.assertEqual('OK', response.data)
@@ -386,7 +386,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
             "product": ["Mortgage-FHA Mortgage", "Payday Loan"]}))
         self.assertEqual('OK', response.data)
@@ -403,7 +403,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "issue": ["Communication tactics-Frequent or repeated calls",
             "Loan servicing, payments, escrow account"]}))
@@ -417,7 +417,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "state": ["CA", "FL", "VA"]}))
         self.assertEqual('OK', response.data)
@@ -430,7 +430,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "zip_code": ["94XXX", "24236", "23456"]}))
         self.assertEqual('OK', response.data)
@@ -443,7 +443,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "timely": ["YES", "NO"]}))
         self.assertEqual('OK', response.data)
@@ -456,7 +456,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "consumer_disputed": ["yes", "no"]}))
         self.assertEqual('OK', response.data)
@@ -469,7 +469,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "company_response": ["Closed", "No response"]}))
         self.assertEqual('OK', response.data)
@@ -482,7 +482,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "company_public_response": ["Closed", "No response"]}))
         self.assertEqual('OK', response.data)
@@ -495,7 +495,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "consumer_consent_provided": ["Yes", "No"]}))
         self.assertEqual('OK', response.data)
@@ -508,7 +508,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "has_narrative": ["Yes", "No"]}))
         self.assertEqual('OK', response.data)
@@ -521,7 +521,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "submitted_via": ["Web", "Phone"]}))
         self.assertEqual('OK', response.data)
@@ -534,7 +534,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # -*- coding: utf-8 -*-
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "tags": ["Older American", "Servicemember"]}))
         self.assertEqual('OK', response.data)
@@ -546,7 +546,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "no_aggs": True}))
         self.assertEqual('OK', response.data)
@@ -569,7 +569,7 @@ class SearchTests(APITestCase):
         mock_essearch.return_value = 'OK'
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(), 
+        mock_essearch.assert_called_once_with(agg_exclude=self.buildDefaultAggExclude(),
             **self.buildDefaultParams({
                 "no_highlight": True}))
         self.assertEqual('OK', response.data)

--- a/complaint_search/tests/test_views_suggest.py
+++ b/complaint_search/tests/test_views_suggest.py
@@ -74,7 +74,7 @@ class SuggestTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         mock_essuggest.assert_not_called()
         self.assertDictEqual(
-            {"size": ["Ensure this value is less than or equal to 100000."]}, 
+            {"size": ["Ensure this value is less than or equal to 100000."]},
             response.data)
 
     @mock.patch('complaint_search.es_interface.suggest')
@@ -90,21 +90,10 @@ class SuggestTests(APITestCase):
         self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
 
     @mock.patch('complaint_search.es_interface.suggest')
-    def test_suggest__transport_error_with_status_code(self, mock_essuggest):
-        mock_essuggest.side_effect = TransportError(status.HTTP_404_NOT_FOUND, "Error")
-        url = reverse('complaint_search:suggest')
-        param = {"text": "test"}
-        response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
-
-    @mock.patch('complaint_search.es_interface.suggest')
-    def test_suggest__transport_error_without_status_code(self, mock_essuggest):
+    def test_suggest__transport_error(self, mock_essuggest):
         mock_essuggest.side_effect = TransportError('N/A', "Error")
         url = reverse('complaint_search:suggest')
         param = {"text": "test"}
         response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertDictEqual({"error": "Elasticsearch error: Error"}, response.data)
-
-
+        self.assertEqual(response.status_code, 424)
+        self.assertDictEqual({"error": "There was an error searching Elasticsearch"}, response.data)

--- a/complaint_search/tests/test_views_suggest.py
+++ b/complaint_search/tests/test_views_suggest.py
@@ -7,6 +7,7 @@ from elasticsearch import TransportError
 import mock
 from complaint_search.es_interface import suggest
 
+
 class SuggestTests(APITestCase):
 
     def setUp(self):
@@ -51,7 +52,9 @@ class SuggestTests(APITestCase):
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.suggest')
-    def test_suggest_with_size__invalid_smaller_than_min_number(self, mock_essuggest):
+    def test_suggest_with_size__invalid_smaller_than_min_number(
+        self, mock_essuggest
+    ):
         url = reverse('complaint_search:suggest')
         params = {"size": 0}
         mock_essuggest.return_value = 'OK'
@@ -59,7 +62,7 @@ class SuggestTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essuggest.assert_not_called()
         self.assertDictEqual(
-            {"size": ["Ensure this value is greater than or equal to 1."]}, 
+            {"size": ["Ensure this value is greater than or equal to 1."]},
             response.data)
 
     @mock.patch('complaint_search.es_interface.suggest')
@@ -96,4 +99,7 @@ class SuggestTests(APITestCase):
         param = {"text": "test"}
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
-        self.assertDictEqual({"error": "There was an error searching Elasticsearch"}, response.data)
+        self.assertDictEqual(
+            {"error": "There was an error calling Elasticsearch"},
+            response.data
+        )

--- a/complaint_search/tests/test_views_suggest_company.py
+++ b/complaint_search/tests/test_views_suggest_company.py
@@ -62,7 +62,6 @@ class SuggestCompanyTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
 
-
     @mock.patch('complaint_search.es_interface.filter_suggest')
     def test_suggest__transport_error(
         self, mock_essuggest
@@ -73,6 +72,6 @@ class SuggestCompanyTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error searching Elasticsearch"}, response.data
+            {"error": "There was an error calling Elasticsearch"},
+            response.data
         )
-

--- a/complaint_search/tests/test_views_suggest_company.py
+++ b/complaint_search/tests/test_views_suggest_company.py
@@ -64,15 +64,15 @@ class SuggestCompanyTests(APITestCase):
 
 
     @mock.patch('complaint_search.es_interface.filter_suggest')
-    def test_suggest__transport_error_without_status_code(
+    def test_suggest__transport_error(
         self, mock_essuggest
     ):
         mock_essuggest.side_effect = TransportError('N/A', "Error")
         url = reverse('complaint_search:suggest_zip')
         param = {"text": "test"}
         response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "Elasticsearch error: Error"}, response.data
+            {"error": "There was an error searching Elasticsearch"}, response.data
         )
 

--- a/complaint_search/tests/test_views_suggest_zip.py
+++ b/complaint_search/tests/test_views_suggest_zip.py
@@ -63,27 +63,14 @@ class SuggestZipTests(APITestCase):
         self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
 
     @mock.patch('complaint_search.es_interface.filter_suggest')
-    def test_suggest__transport_error_with_status_code(self, mock_essuggest):
-        mock_essuggest.side_effect = TransportError(
-            status.HTTP_404_NOT_FOUND, "Error"
-        )
-        url = reverse('complaint_search:suggest_zip')
-        param = {"text": "test"}
-        response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertDictEqual(
-            {"error": "Elasticsearch error: Error"}, response.data
-        )
-
-    @mock.patch('complaint_search.es_interface.filter_suggest')
-    def test_suggest__transport_error_without_status_code(
+    def test_suggest__transport_error(
         self, mock_essuggest
     ):
         mock_essuggest.side_effect = TransportError('N/A', "Error")
         url = reverse('complaint_search:suggest_zip')
         param = {"text": "test"}
         response = self.client.get(url, param)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "Elasticsearch error: Error"}, response.data
+            {"error": "There was an error searching Elasticsearch"}, response.data
         )

--- a/complaint_search/tests/test_views_suggest_zip.py
+++ b/complaint_search/tests/test_views_suggest_zip.py
@@ -72,5 +72,6 @@ class SuggestZipTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error searching Elasticsearch"}, response.data
+            {"error": "There was an error calling Elasticsearch"},
+            response.data
         )


### PR DESCRIPTION
Work on https://github.com/cfpb/ccdb5-api/issues/74

## Changes
1. Switches the error code to 424 when Elasticsearch is not available
1. When a truly unexpected condition happens (like happened 6/20-6/21), it catches the error and returns 500
1. The error details are logged, but not returned to the user
1. The default response is `{}` not `None` which can be handled by the StreamResponse

## Other non-relevant changes
1. PEP 8 fixes (mostly whitespace)