### PR TITLE
Export Script

### DIFF
--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -18,21 +18,15 @@ sys.setdefaultencoding('utf8')
 
 class ElasticSearchExporter(object):
 
-    # export_1 - query Elasticsearch and stream the response as a CSV
+    # export_csv - Stream an Elsticsearch response as a CSV file
     #
     # Parameters:
-    # - es (Elasticsearch instance)
-    #   The Elasticsearch instance to query against
-    # - index (string)
-    #   The Elasticsearch index to query against
-    # - doc_type (string)
-    #   The document type in the desired index
-    # - body (string)
-    #   The body of the Elasticsearch query
+    # - scanResponse (generator)
+    #   The response from an Elasticsaerch scan query
     # - header_dict (OrderedDict)
     #   The ordered dictionary where the key is the Elasticsearch field name
     #   and the value is the CSV column header for that field 
-    def export_1(self, es, index, doc_type, body, header_dict):
+    def export_csv(self, scanResponse, header_dict, max_size=5000):
         def read_and_flush(writer, buffer_, row):
             writer.writerow(row)
             buffer_.seek(0)
@@ -45,17 +39,18 @@ class ElasticSearchExporter(object):
             buffer_ = StringIO.StringIO()
             writer = csv.DictWriter(buffer_, header_dict.keys(), 
                 delimiter=",",quoting=csv.QUOTE_MINIMAL)
-
-            scanResponse = helpers.scan(client=es, query=body, scroll= "10m", 
-                index=index, size=body["size"], doc_type=doc_type, 
-                request_timeout=3000)
             
             # Write Header Row
             data = read_and_flush(writer, buffer_, header_dict)
             yield data
 
+            count = 0
             # Write CSV
             for row in scanResponse:
+                if count >= max_size:
+                    break
+                else:
+                    count += 1
                 rows_data = {key: unicode(value) for key, value in row['_source'].iteritems()
                              if key in header_dict.keys()}
 
@@ -69,43 +64,25 @@ class ElasticSearchExporter(object):
         return response
 
 
-    # export_2 - Stream an Elsticsearch response as a CSV
+    # export_json - Stream an Elsticsearch response as a JSON file
     #
     # Parameters:
     # - scanResponse (generator)
     #   The response from an Elasticsaerch scan query
-    # - header_dict (OrderedDict)
-    #   The ordered dictionary where the key is the Elasticsearch field name
-    #   and the value is the CSV column header for that field 
-    def export_2(self, scanResponse, header_dict):
-        def read_and_flush(writer, buffer_, row):
-            writer.writerow(row)
-            buffer_.seek(0)
-            data = buffer_.read()
-            buffer_.seek(0)
-            buffer_.truncate()
-            return data
-
+    def export_json(self, scanResponse, max_size=5000):
         def stream():
-            buffer_ = StringIO.StringIO()
-            writer = csv.DictWriter(buffer_, header_dict.keys(), 
-                delimiter=",",quoting=csv.QUOTE_MINIMAL)
-            
-            # Write Header Row
-            data = read_and_flush(writer, buffer_, header_dict)
-            yield data
-
-            # Write CSV
+            count = 0
+            # Write JSON
             for row in scanResponse:
-                rows_data = {key: unicode(value) for key, value in row['_source'].iteritems()
-                             if key in header_dict.keys()}
-
-                data = read_and_flush(writer, buffer_, rows_data)
-                yield data
+                if count >= max_size:
+                    break
+                else:
+                    count += 1
+                yield json.dumps(row)
 
         response = StreamingHttpResponse(
-            stream(), content_type='text/csv'
+            stream(), content_type='text/json'
         )
-        response['Content-Disposition'] = "attachment; filename=file.csv"
+        response['Content-Disposition'] = "attachment; filename=file.json"
         return response
 

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import io
+import json
+from collections import namedtuple, OrderedDict
+from django.http import StreamingHttpResponse
+from django.test import TestCase
+from nose_parameterized import parameterized
+
+from v2.export import ElasticSearchExporter
+
+
+TEST_HEADERS = OrderedDict([
+    ("first_entry", "First Entry"),
+    ("second_entry", "Second Entry"),
+    ("third_entry", "Third Entry"),
+    ("fourth_entry", "Fourth Entry"),
+])
+
+def es_generator(n):
+    count = 0
+    while count < n:
+        yield {
+            '_source':  {
+                'first_entry': 'Random 1',
+                'second_entry': 'Random 2',
+                'third_entry': 'Random 3',
+                'fourth_entry': 'Random 4'
+            }
+        }
+        count += 1
+    
+
+class ExportTest(TestCase):
+    @parameterized.expand([
+        [10],
+        [5010],
+        [100000]
+    ])
+    def test_export_csv_request_response(self, length):
+        # arrange
+        es_exporter = ElasticSearchExporter()
+        gen = es_generator(length)
+        
+        # act
+        res = es_exporter.export_csv(gen, TEST_HEADERS)
+
+        # assert
+        self.assertTrue(isinstance(res, StreamingHttpResponse))
+
+        # mock_search.assert_not_called()
+        self.assertEqual(res.get('Content-Disposition'), "attachment; filename=file.csv")
+        self.assertTrue('itertools.imap' in str(type(res.streaming_content)))
+        downloaded_file = io.BytesIO(b"".join(res.streaming_content))
+        self.assertTrue(not downloaded_file == None)
+
+
+    @parameterized.expand([
+        [10],
+        [5010],
+        [100000]
+    ])
+    def test_export_json_request_response(self, length):
+        # arrange
+        es_exporter = ElasticSearchExporter()
+        gen = es_generator(length)
+        
+        # act
+        res = es_exporter.export_json(gen)
+
+        # assert
+        self.assertTrue(isinstance(res, StreamingHttpResponse))
+
+        # mock_search.assert_not_called()
+        self.assertEqual(res.get('Content-Disposition'), "attachment; filename=file.json")
+        self.assertTrue('itertools.imap' in str(type(res.streaming_content)))
+        downloaded_file = io.BytesIO(b"".join(res.streaming_content))
+        self.assertTrue(not downloaded_file == None)
+

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -7,7 +7,7 @@ from django.http import StreamingHttpResponse
 from django.test import TestCase
 from nose_parameterized import parameterized
 
-from v2.export import ElasticSearchExporter
+from complaint_search.export import ElasticSearchExporter
 
 
 TEST_HEADERS = OrderedDict([

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ testing_extras = [
     'coverage>=4.5.1,<5',
     'mock==2.0.0',
     'deep==0.10',
+    'django-nose==1.4.1',
+    'parameterized==0.6.1',
 ]
 
 docs_extras = [


### PR DESCRIPTION
* Adds the export script and unit tests

`export.py` script uses Django to create and export CSV and JSON files of complaint data for users. This takes the processing burden off of Elasticsearch/dataformat plugin.

https://github.cfpb.gov/data-products-team/explorer-docs/issues/460