### PR TITLE
Requests version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Requirements are retrieved and/or build automatically via pip (see below).
 * djangorestframework - Rest API framework
 * elasticsearch - low level client for Elasticsearch
 * requests - http requests to get different data format
-* urllib3 - http client library to help format http URL
 
 
 ## Setup & Running

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,5 +1,4 @@
 import os
-import urllib
 import json
 import copy
 import time

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -52,19 +52,6 @@ def load(shortName):
     with open(fileName, 'r') as f:
         return json.load(f)
 
-def es_generator(n):
-    count = 0
-    while count < n:
-        yield {
-            '_source':  {
-                'first_entry': 'Random 1',
-                'second_entry': 'Random 2',
-                'third_entry': 'Random 3',
-                'fourth_entry': 'Random 4'
-            }
-        }
-        count += 1
-
 
 class EsInterfaceTest_Search(TestCase):
     # -------------------------------------------------------------------------
@@ -330,7 +317,6 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(ElasticSearchExporter, 'export_json')
     @mock.patch('elasticsearch.helpers.scan')
     def test_search_with_format__valid(self, export_type, mock_es_helper, mock_exporter_json, mock_exporter_csv):
-        mock_es_helper.return_value = es_generator(10)
         mock_exporter_csv.return_value = StreamingHttpResponse()
         mock_exporter_json.return_value = StreamingHttpResponse()
 

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -29,6 +29,7 @@ from complaint_search.stream_content import (
 from datetime import datetime
 from elasticsearch import Elasticsearch
 from collections import namedtuple
+from nose_parameterized import parameterized
 import copy
 import deep
 import mock
@@ -320,33 +321,30 @@ class EsInterfaceTest_Search(TestCase):
     #     mock_search.assert_not_called()
     #     self.assertEqual(1, mock_rget.call_count)
 
-    @mock.patch.object(ElasticSearchExporter, 'export_csv')
-    @mock.patch('elasticsearch.helpers.scan')
-    def test_search_with_format_csv__valid(self, mock_es_helper, mock_exporter):
-        mock_es_helper.return_value = es_generator(10)
-        mock_exporter.return_value = StreamingHttpResponse()
 
-        format = 'csv'
+    @parameterized.expand([
+        ['csv'],
+        ['json']
+    ])
+    @mock.patch.object(ElasticSearchExporter, 'export_csv')
+    @mock.patch.object(ElasticSearchExporter, 'export_json')
+    @mock.patch('elasticsearch.helpers.scan')
+    def test_search_with_format__valid(self, export_type, mock_es_helper, mock_exporter_json, mock_exporter_csv):
+        mock_es_helper.return_value = es_generator(10)
+        mock_exporter_csv.return_value = StreamingHttpResponse()
+        mock_exporter_json.return_value = StreamingHttpResponse()
+
+        format = export_type
         res = search(format=format)
         
         self.assertIsInstance(res, StreamingHttpResponse)
-        self.assertEqual(str(type(res.streaming_content)), "<type 'itertools.imap'>")
         self.assertEqual(1, mock_es_helper.call_count)
-        self.assertEqual(1, mock_exporter.call_count)
-
-    @mock.patch.object(ElasticSearchExporter, 'export_json')
-    @mock.patch('elasticsearch.helpers.scan')
-    def test_search_with_format_json__valid(self, mock_es_helper, mock_exporter):
-        mock_es_helper.return_value = es_generator(10)
-        mock_exporter.return_value = StreamingHttpResponse()
-
-        format = 'json'
-        res = search(format=format)
-        
-        self.assertTrue(isinstance(res, StreamingHttpResponse))
-        self.assertEqual(str(type(res.streaming_content)), "<type 'itertools.imap'>")
-        self.assertEqual(1, mock_es_helper.call_count)
-        self.assertEqual(1, mock_exporter.call_count)
+        if export_type == 'csv':
+            self.assertEqual(1, mock_exporter_csv.call_count)
+            self.assertEqual(0, mock_exporter_json.call_count)
+        else:
+            self.assertEqual(1, mock_exporter_json.call_count)
+            self.assertEqual(0, mock_exporter_csv.call_count)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._get_meta")

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -322,31 +322,31 @@ class EsInterfaceTest_Search(TestCase):
 
     @mock.patch.object(ElasticSearchExporter, 'export_csv')
     @mock.patch('elasticsearch.helpers.scan')
-    def test_search_with_format_csv__valid(self, mock_search, mock_exporter):
-        mock_search.return_value = es_generator(10)
+    def test_search_with_format_csv__valid(self, mock_es_helper, mock_exporter):
+        mock_es_helper.return_value = es_generator(10)
         mock_exporter.return_value = StreamingHttpResponse()
 
-        body = load("search_with_format_csv__valid")
         format = 'csv'
         res = search(format=format)
         
-        self.assertTrue(isinstance(res, StreamingHttpResponse))
+        self.assertIsInstance(res, StreamingHttpResponse)
         self.assertEqual(str(type(res.streaming_content)), "<type 'itertools.imap'>")
-        self.assertEqual(1, mock_search.call_count)
+        self.assertEqual(1, mock_es_helper.call_count)
+        self.assertEqual(1, mock_exporter.call_count)
 
     @mock.patch.object(ElasticSearchExporter, 'export_json')
     @mock.patch('elasticsearch.helpers.scan')
-    def test_search_with_format_json__valid(self, mock_search, mock_exporter):
-        mock_search.return_value = es_generator(10)
+    def test_search_with_format_json__valid(self, mock_es_helper, mock_exporter):
+        mock_es_helper.return_value = es_generator(10)
         mock_exporter.return_value = StreamingHttpResponse()
 
-        body = load("search_with_format_json__valid")
-        format = 'csv'
+        format = 'json'
         res = search(format=format)
         
         self.assertTrue(isinstance(res, StreamingHttpResponse))
         self.assertEqual(str(type(res.streaming_content)), "<type 'itertools.imap'>")
-        self.assertEqual(1, mock_search.call_count)
+        self.assertEqual(1, mock_es_helper.call_count)
+        self.assertEqual(1, mock_exporter.call_count)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._get_meta")

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'Django>=1.11,<1.12',
     'djangorestframework>=3.6,<3.9',
     'elasticsearch>=2.4.1,<3',
-    'requests>=2.18.4,<2.20',
+    'requests>=2.18.4,<2.20.1',
     'django-localflavor>=1.1,<2',
     'django-flags>=3.0.2,<4',
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'Django>=1.11,<1.12',
     'djangorestframework>=3.6,<3.9',
     'elasticsearch>=2.4.1,<3',
-    'requests==2.20.1',
+    'requests>=2.18.4,<2.20',
     'django-localflavor>=1.1,<2',
     'django-flags>=3.0.2,<4',
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'Django>=1.11,<1.12',
     'djangorestframework>=3.6,<3.9',
     'elasticsearch>=2.4.1,<3',
-    'requests>=2.18.4,<2.20.1',
+    'requests>=2.18.4,<2.20',
     'django-localflavor>=1.1,<2',
     'django-flags>=3.0.2,<4',
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 install_requires = [
     'Django>=1.11,<1.12',
     'djangorestframework>=3.6,<3.9',
-    'elasticsearch>=2.4.1,<3',
     'requests>=2.18.4,<2.20',
+    'elasticsearch>=2.4.1,<3',
     'django-localflavor>=1.1,<2',
     'django-flags>=3.0.2,<4',
 ]


### PR DESCRIPTION
Test to see if the latest changes (Export script) will pass tests with a version range for `requests`. Previously this range led to Travis failures, which was why it was pinned to 2.20.1.