### PR TITLE
Update version of django-flags to 4.0.x

### DIFF
--- a/ccdb5_api/settings.py
+++ b/ccdb5_api/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'rest_framework',
     'complaint_search',
+    'flags',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -116,7 +116,7 @@ def _get_meta():
         "total_record_count": count_res["count"],
         "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_date"]["value_as_string"]),
         "is_narrative_stale": _is_data_stale(from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"])),
-        "has_data_issue": flag_enabled('CCDB_TECHNICAL_ISSUES')
+        "has_data_issue": bool(flag_enabled('CCDB_TECHNICAL_ISSUES'))
     }
 
     return result

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'elasticsearch>=2.4.1,<3',
     'requests==2.20.1',
     'django-localflavor>=1.1,<2',
-    'django-flags>=3.0.2,<4',
+    'django-flags>=4.0.1,<5',
 ]
 
 testing_extras = [


### PR DESCRIPTION
As of https://github.com/cfpb/cfgov-refresh/pull/4641, cf.gov uses version 4.0.1 of the [django-flags](https://github.com/cfpb/django-flags) package. This package currently requires >=3.0.2,<4, and so this requirement needs to be updated to remain compatible.

There are several breaking changes in django-flags 4.0 which need to be addressed here as well:

1. Because of the way the django-flags 4.0 loads flag conditions from the database, the "flags" app must be included in Django settings `INSTALLED_APPS`. This commit modifies the test settings to do so.
2. If a flag is undefined, the flag_enabled() method now returns None instead of False. This package has some tests and logic that assume that the value is False, so this commit converts the return value to a boolean.

All unit tests pass properly with this change.