### PR TITLE
Size limit

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -166,6 +166,9 @@ def search(agg_exclude=None, **kwargs):
     res = {}
     format = params.get("format")
     if format == "default":
+        if body["size"] > 100:
+            body["size"] = 100
+        
         if not params.get("no_aggs"):
             aggregation_builder = AggregationBuilder()
             aggregation_builder.add(**params)
@@ -178,7 +181,7 @@ def search(agg_exclude=None, **kwargs):
                                body=body,
                                scroll="10m")
 
-        num_of_scroll = params.get("frm") / params.get("size")
+        num_of_scroll = params.get("frm") / body["size"]
         scroll_id = res['_scroll_id']
         if num_of_scroll > 0:
             while num_of_scroll > 0:

--- a/complaint_search/tests/expected_results/search_with_size_corrected__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size_corrected__valid.json
@@ -1,0 +1,284 @@
+{
+    "from": 0,
+  "_source": [
+    "company",
+    "company_public_response",
+    "company_response",
+    "complaint_id",
+    "complaint_what_happened",
+    "consumer_consent_provided",
+    "consumer_disputed",
+    "date_received",
+    "date_sent_to_company",
+    "has_narrative",
+    "issue",
+    "product",
+    "state",
+    "submitted_via",
+    "sub_issue",
+    "sub_product",
+    "tags",
+    "timely",
+    "zip_code"
+  ],
+    "size": 500,
+    "query": {
+        "query_string": {
+            "query": "*",
+            "fields": [
+                "complaint_what_happened"
+            ],
+            "default_operator": "AND"
+        }
+    },
+    "highlight": {
+        "require_field_match": false,
+        "fields": {
+            "complaint_what_happened": {}
+        },
+        "number_of_fragments": 1,
+        "fragment_size": 500
+    },
+    "sort": [{"_score": {"order": "desc"}}],
+    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
+    "aggs": {
+        "has_narrative": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "has_narrative": {
+                    "terms": {
+                        "field": "has_narrative",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "company": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "company": {
+                    "terms": {
+                        "field": "company.raw",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "product": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "product": {
+                    "terms": {
+                        "field": "product.raw",
+                        "size": 0
+                    },
+                    "aggs": {
+                        "sub_product.raw": {
+                            "terms": {
+                                "field": "sub_product.raw",
+                                "size": 0
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "issue": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "issue": {
+                    "terms": {
+                        "field": "issue.raw",
+                        "size": 0
+                    },
+                    "aggs": {
+                        "sub_issue.raw": {
+                            "terms": {
+                                "field": "sub_issue.raw",
+                                "size": 0
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "state": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "state": {
+                    "terms": {
+                        "field": "state",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "zip_code": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "zip_code": {
+                    "terms": {
+                        "field": "zip_code",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "timely": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "timely": {
+                    "terms": {
+                        "field": "timely",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "company_response": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "company_response": {
+                    "terms": {
+                        "field": "company_response",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "company_public_response": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "company_public_response": {
+                    "terms": {
+                        "field": "company_public_response.raw",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "consumer_disputed": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "consumer_disputed": {
+                    "terms": {
+                        "field": "consumer_disputed.raw",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "consumer_consent_provided": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "consumer_consent_provided": {
+                    "terms": {
+                        "field": "consumer_consent_provided.raw",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "tags": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "tags": {
+                    "terms": {
+                        "field": "tags",
+                        "size": 0
+                    }
+                }
+            }
+        },
+        "submitted_via": {
+            "filter": {
+                "bool": {
+                    "filter": [],
+                    "must": [],
+                    "should": []
+                }
+            },
+            "aggs": {
+                "submitted_via": {
+                    "terms": {
+                        "field": "submitted_via",
+                        "size": 0
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -428,6 +428,22 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
+    def test_search_with_size_corrected__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
+        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+        mock_get_meta.return_value = copy.deepcopy(
+            self.MOCK_SEARCH_RESULT["_meta"])
+        body = load("search_with_size_corrected__valid")
+        res = search(size=500)
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        self.assertEqual(100, mock_search.call_args_list[0][1]['body']['size'])
+        mock_scroll.assert_not_called()
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch("complaint_search.es_interface._get_meta")
+    @mock.patch.object(Elasticsearch, 'search')
+    @mock.patch.object(Elasticsearch, 'count')
+    @mock.patch.object(Elasticsearch, 'scroll')
     def test_search_with_frm__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE

--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -512,7 +512,7 @@ parameters:
     in: "query"
     description: "Limit the size of the results"
     type: "integer"
-    maximum: 100000
+    maximum: 100
     minimum: 1
     format: "int64"
     default: 10


### PR DESCRIPTION
Enforce a maximum limit on the size parameter of 100. If the size parameter is provided to an API with a size greater than 100 it will be automatically resized to 100 to prevent DDOS attacks.

This change requires an update in the pagination logic which is captured in [this PR](https://github.com/cfpb/ccdb5-ui/pull/140)