### PR TITLE
Make the tests pass in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
 - '2.7'
+- '3.6'
 install:
+- pip install tox-travis
 - pip install tox
 - pip install coveralls
 script:

--- a/ccdb5_api/settings.py
+++ b/ccdb5_api/settings.py
@@ -12,7 +12,9 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+
 from django.utils.crypto import get_random_string
+
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/ccdb5_api/urls.py
+++ b/ccdb5_api/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 
+
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^', include('complaint_search.urls', namespace="complaint_search")),

--- a/ccdb5_api/wsgi.py
+++ b/ccdb5_api/wsgi.py
@@ -11,6 +11,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ccdb5_api.settings")
 
 application = get_wsgi_application()

--- a/complaint_search/admin.py
+++ b/complaint_search/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+# from django.contrib import admin
 
 # Register your models here.

--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -1,7 +1,9 @@
 import logging
+
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.response import Response
-from elasticsearch import TransportError
+
 
 log = logging.getLogger(__name__)
 

--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 
+
 PARAMS = {
     "format": "default",
     "field": "complaint_what_happened",

--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 
 PARAMS = {
@@ -42,7 +44,7 @@ EXPORT_FORMATS = (
 
 CSV_ORDERED_HEADERS = OrderedDict([
     ("date_received_formatted", "Date received"),
-    ("product", "Product"), 
+    ("product", "Product"),
     ("sub_product", "Sub-product"),
     ("issue", "Issue"),
     ("sub_issue", "Sub-issue"),

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -1,12 +1,13 @@
-import re
-import copy
 import abc
+import copy
+import re
 from collections import OrderedDict
+
 from complaint_search.defaults import (
     DELIMITER,
     EXPORT_FORMATS,
     PARAMS,
-    SOURCE_FIELDS
+    SOURCE_FIELDS,
 )
 
 
@@ -398,10 +399,11 @@ class AggregationBuilder(BaseBuilder):
 
         return aggs
 
+
 if __name__ == "__main__":
     searchbuilder = SearchBuilder()
-    print searchbuilder.build()
+    print(searchbuilder.build())
     pfbuilder = PostFilterBuilder()
-    print pfbuilder.build()
+    print(pfbuilder.build())
     aggbuilder = AggregationBuilder()
-    print aggbuilder.build()
+    print(aggbuilder.build())

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -73,23 +73,31 @@ class BaseBuilder(object):
     def build(self):
         """Method that will build the body dictionary."""
 
-    ## This create all the bool should filter clauses for a field
-    ## es_field_name: a field name (to be filtered in ES)
-    ## value_list: a list of values to be filtered for this field
-    ## with_child: set to true if this field has a child field
-    ## es_child_field_name: if with_child is true, this holds the field
-    ## name of the child used (to be filtered in ES)
+    # This create all the bool should filter clauses for a field
+    # es_field_name: a field name (to be filtered in ES)
+    # value_list: a list of values to be filtered for this field
+    # with_child: set to true if this field has a child field
+    # es_child_field_name: if with_child is true, this holds the field
+    # name of the child used (to be filtered in ES)
     def _build_bool_clauses(self, field):
         es_field_name = self._get_es_name(field)
-        value_list = [0 if cd.lower() == "no" else 1 for cd in self.params[field]] \
-            if field in self._OPTIONAL_FILTERS_STRING_TO_BOOL else self.params.get(field)
+        value_list = (
+            [
+                0 if cd.lower() == "no" else 1 for cd in self.params[field]
+            ]
+            if field in self._OPTIONAL_FILTERS_STRING_TO_BOOL
+            else self.params.get(field)
+        )
 
         if value_list:
 
-            # MUST filters must be in parallel otherwise they will not execute as intended
+            # MUST filters must be in parallel otherwise they will not execute
+            # as intended
             if field in self._OPTIONAL_FILTERS_MUST:
                 term_list_container = []
-                term_list = [{"terms": {es_field_name: [value]}} for value in value_list]
+                term_list = [
+                    {"terms": {es_field_name: [value]}} for value in value_list
+                ]
 
                 return term_list
 
@@ -117,20 +125,29 @@ class BaseBuilder(object):
                     if not child:
                         f_list.append(parent_term)
                     else:
-                        child_term = {"terms": {self._get_es_name(self._get_child(field)): child}}
-                        parent_child_bool_structure = {"bool": {"must": [], "should": []}}
-                        parent_child_bool_structure["bool"]["must"].append(parent_term)
-                        parent_child_bool_structure["bool"]["should"].append(child_term)
+                        child_term = {"terms": {
+                            self._get_es_name(self._get_child(field)): child
+                        }}
+                        parent_child_bool_structure = {"bool": {
+                            "must": [], "should": []
+                        }}
+                        parent_child_bool_structure["bool"]["must"].append(
+                            parent_term)
+                        parent_child_bool_structure["bool"]["should"].append(
+                            child_term)
 
                         f_list.append(parent_child_bool_structure)
 
                 return f_list
 
-    # This creates a dictionary of all filter_clauses, where the keys are the field name
+    # This creates a dictionary of all filter_clauses, where the keys are the
+    # field name
     def _build_filter_clauses(self):
         filter_clauses = {}
         for item in self.params:
-            if item in self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL + self._OPTIONAL_FILTERS_MUST:
+            if item in (self._OPTIONAL_FILTERS +
+                        self._OPTIONAL_FILTERS_STRING_TO_BOOL +
+                        self._OPTIONAL_FILTERS_MUST):
                 filter_clauses[item] = self._build_bool_clauses(item)
         return filter_clauses
 
@@ -143,7 +160,7 @@ class BaseBuilder(object):
                 d = str(date_min) + timeSuffix
                 date_clause["range"][es_field_name]["from"] = d
             if date_max:
-                d =  str(date_max) + timeSuffix
+                d = str(date_max) + timeSuffix
                 date_clause["range"][es_field_name]["to"] = d
 
         return date_clause
@@ -160,7 +177,7 @@ class SearchBuilder(BaseBuilder):
             "fragment_size": 500
         }
         if self.params.get("field") == "_all":
-            highlight["fields"] = { source: {} for source in SOURCE_FIELDS }
+            highlight["fields"] = {source: {} for source in SOURCE_FIELDS}
         else:
             highlight["fields"] = {self.params.get("field"): {}}
 
@@ -213,9 +230,9 @@ class SearchBuilder(BaseBuilder):
         # query
         search_term = self.params.get("search_term")
         if search_term:
-            if re.match("^[A-Za-z\d\s]+$", search_term) and \
-            not any(keyword in search_term
-                for keyword in ("AND", "OR", "NOT", "TO")):
+            if (re.match(r"^[A-Za-z\d\s]+$", search_term) and not
+                any(keyword in search_term
+                    for keyword in ("AND", "OR", "NOT", "TO"))):
 
                 # Match Query
                 search["query"] = {
@@ -250,7 +267,7 @@ class PostFilterBuilder(BaseBuilder):
 
         post_filter = {"bool": {"should": [], "must": [], "filter": []}}
 
-        ## date_received
+        # date_received
         date_received = self._build_date_range_filter(
             self.params.get("date_received_min"),
             self.params.get("date_received_max"),
@@ -259,7 +276,7 @@ class PostFilterBuilder(BaseBuilder):
         if date_received:
             post_filter["bool"]["filter"].append(date_received)
 
-        ## company_received
+        # company_received
         company_received = self._build_date_range_filter(
             self.params.get("company_received_min"),
             self.params.get("company_received_max"),
@@ -268,13 +285,16 @@ class PostFilterBuilder(BaseBuilder):
         if company_received:
             post_filter["bool"]["filter"].append(company_received)
 
-        ## Create filter clauses for all other filters
+        # Create filter clauses for all other filters
         for item in self.params:
-            if item in self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL:
-                # for filters selected, we are creating the field level OR query that must match
-                # e.g (this OR that) AND (y or z) AND servicemember
-                field_level_should = {"bool": {"should":filter_clauses[item]}}
-                post_filter["bool"]["filter"].append( field_level_should )
+            if item in (
+                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+            ):
+                # for filters selected, we are creating the field level OR
+                # query that must match e.g (this OR that) AND (y or z) AND
+                # servicemember
+                field_level_should = {"bool": {"should": filter_clauses[item]}}
+                post_filter["bool"]["filter"].append(field_level_should)
             if item in self._OPTIONAL_FILTERS_MUST:
                 post_filter["bool"]["filter"].append(filter_clauses[item])
 
@@ -372,9 +392,14 @@ class AggregationBuilder(BaseBuilder):
         # the same as field name or part of the exclude list, which means we
         # want to list all matched aggregation)
         for item in self.params:
-            include_filter = item != field_name or (item == field_name and item in self.exclude)
+            include_filter = (
+                item != field_name or
+                (item == field_name and item in self.exclude)
+            )
 
-            if include_filter and item in self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL:
+            if include_filter and item in (
+                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+            ):
                 field_level_should = {
                     "bool": {"should": self.filter_clauses[item]}
                 }
@@ -394,8 +419,9 @@ class AggregationBuilder(BaseBuilder):
 
         agg_fields = self._AGG_FIELDS
         if self.exclude:
-            agg_fields = [ field_name for field_name in self._AGG_FIELDS
-                if field_name not in self.exclude or field_name in self.params ]
+            agg_fields = [field_name for field_name in self._AGG_FIELDS
+                          if field_name not in self.exclude
+                          or field_name in self.params]
         for field_name in agg_fields:
             aggs[field_name] = self.build_one(field_name)
 

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import abc
 import copy
 import re
@@ -109,7 +111,7 @@ class BaseBuilder(object):
 
                 # Go through item_dict to create filters
                 f_list = []
-                for item, child in item_dict.iteritems():
+                for item, child in item_dict.items():
                     # Always append the item to list
                     parent_term = {"terms": {es_field_name: [item]}}
                     if not child:
@@ -119,9 +121,9 @@ class BaseBuilder(object):
                         parent_child_bool_structure = {"bool": {"must": [], "should": []}}
                         parent_child_bool_structure["bool"]["must"].append(parent_term)
                         parent_child_bool_structure["bool"]["should"].append(child_term)
-                        
+
                         f_list.append(parent_child_bool_structure)
-                
+
                 return f_list
 
     # This creates a dictionary of all filter_clauses, where the keys are the field name
@@ -367,7 +369,7 @@ class AggregationBuilder(BaseBuilder):
             field_aggs["filter"]["bool"]["filter"].append(company_filter)
 
         # Add filter clauses to aggregation entries (only those that are not
-        # the same as field name or part of the exclude list, which means we 
+        # the same as field name or part of the exclude list, which means we
         # want to list all matched aggregation)
         for item in self.params:
             include_filter = item != field_name or (item == field_name and item in self.exclude)

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import copy
 import json
 import logging
@@ -106,7 +108,7 @@ def _get_meta():
         }
     }
     max_date_res = _get_es().search(index=_COMPLAINT_ES_INDEX, body=body)
-    count_res = _get_es().count(index=_COMPLAINT_ES_INDEX, 
+    count_res = _get_es().count(index=_COMPLAINT_ES_INDEX,
         doc_type=_COMPLAINT_DOC_TYPE)
 
     result = {
@@ -169,7 +171,7 @@ def search(agg_exclude=None, **kwargs):
     if format == "default":
         if body["size"] > 100:
             body["size"] = 100
-        
+
         if not params.get("no_aggs"):
             aggregation_builder = AggregationBuilder()
             aggregation_builder.add(**params)
@@ -192,8 +194,8 @@ def search(agg_exclude=None, **kwargs):
         res["_meta"] = _get_meta()
 
     elif format in EXPORT_FORMATS:
-        scanResponse = helpers.scan(client=_get_es(), query=body, scroll= "10m", 
-                index=_COMPLAINT_ES_INDEX, size=7000, doc_type=_COMPLAINT_DOC_TYPE, 
+        scanResponse = helpers.scan(client=_get_es(), query=body, scroll= "10m",
+                index=_COMPLAINT_ES_INDEX, size=7000, doc_type=_COMPLAINT_DOC_TYPE,
                 request_timeout=3000)
 
         exporter = ElasticSearchExporter()

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,16 +1,11 @@
 from __future__ import unicode_literals
 
 import copy
-import json
 import logging
 import os
-import time
-from collections import defaultdict, namedtuple
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
-import requests
 from complaint_search.defaults import (
-    CHUNK_SIZE,
     CSV_ORDERED_HEADERS,
     EXPORT_FORMATS,
     PARAMS,
@@ -21,10 +16,6 @@ from complaint_search.es_builders import (
     SearchBuilder,
 )
 from complaint_search.export import ElasticSearchExporter
-from complaint_search.stream_content import (
-    StreamCSVContent,
-    StreamJSONContent,
-)
 from elasticsearch import Elasticsearch, helpers
 from flags.state import flag_enabled
 
@@ -43,8 +34,11 @@ _COMPLAINT_DOC_TYPE = os.environ.get('COMPLAINT_DOC_TYPE', 'complaint-doctype')
 def _get_es():
     global _ES_INSTANCE
     if _ES_INSTANCE is None:
-        _ES_INSTANCE = Elasticsearch([_ES_URL], http_auth=(_ES_USER, _ES_PASSWORD),
-                                     timeout=100)
+        _ES_INSTANCE = Elasticsearch(
+            [_ES_URL],
+            http_auth=(_ES_USER, _ES_PASSWORD),
+            timeout=100
+        )
     return _ES_INSTANCE
 
 
@@ -72,7 +66,8 @@ def _is_data_stale(last_updated_time):
 
 
 def from_timestamp(seconds):
-    # Socrata fields (:field_name) are indexed in seconds, not the usual milliseconds
+    # Socrata fields (:field_name) are indexed in seconds, not the usual
+    # milliseconds
     fromtimestamp = datetime.fromtimestamp(seconds)
     return fromtimestamp.strftime('%Y-%m-%d')
 
@@ -108,16 +103,24 @@ def _get_meta():
         }
     }
     max_date_res = _get_es().search(index=_COMPLAINT_ES_INDEX, body=body)
-    count_res = _get_es().count(index=_COMPLAINT_ES_INDEX,
-        doc_type=_COMPLAINT_DOC_TYPE)
+    count_res = _get_es().count(
+        index=_COMPLAINT_ES_INDEX,
+        doc_type=_COMPLAINT_DOC_TYPE
+    )
 
     result = {
         "license": "CC0",
-        "last_updated": max_date_res["aggregations"]["max_date"]["value_as_string"],
-        "last_indexed": max_date_res["aggregations"]["max_indexed_date"]["value_as_string"],
+        "last_updated":
+            max_date_res["aggregations"]["max_date"]["value_as_string"],
+        "last_indexed":
+            max_date_res["aggregations"]["max_indexed_date"]
+            ["value_as_string"],
         "total_record_count": count_res["count"],
-        "is_data_stale": _is_data_stale(max_date_res["aggregations"]["max_date"]["value_as_string"]),
-        "is_narrative_stale": _is_data_stale(from_timestamp(max_date_res["aggregations"]["max_narratives"]["max_date"]["value"])),
+        "is_data_stale": _is_data_stale(
+            max_date_res["aggregations"]["max_date"]["value_as_string"]),
+        "is_narrative_stale": _is_data_stale(from_timestamp(
+            max_date_res["aggregations"]["max_narratives"]["max_date"]["value"]
+        )),
         "has_data_issue": bool(flag_enabled('CCDB_TECHNICAL_ISSUES'))
     }
 
@@ -125,25 +128,36 @@ def _get_meta():
 
 # List of possible arguments:
 # - format: format to be returned: "json", "csv"
-# - field: field you want to search in: "complaint_what_happened", "company_public_response", "_all"
+# - field: field you want to search in: "complaint_what_happened",
+#   "company_public_response", "_all"
 # - size: number of complaints to return
 # - frm: from which index to start returning
-# - sort: sort by: "relevance_desc", "relevance_asc", "created_date_desc", "created_date_asc"
+# - sort: sort by: "relevance_desc", "relevance_asc", "created_date_desc",
+#   "created_date_asc"
 # - search_term: the term to be searched
-# - date_received_min: return only date received including and later than this date i.e. 2017-03-02
-# - date_received_max: return only date received before this date, i.e. 2017-04-12
-# - company_received_min: return only date company received including and later than this date i.e. 2017-03-02
-# - company_received_max: return only date company received before this date, i.e. 2017-04-12
+# - date_received_min: return only date received including and later than this
+#   date i.e. 2017-03-02
+# - date_received_max: return only date received before this date, i.e.
+#   2017-04-12
+# - company_received_min: return only date company received including and later
+#   than this date i.e. 2017-03-02
+# - company_received_max: return only date company received before this date,
+#   i.e. 2017-04-12
 # - company: filters a list of companies you want ["Bank 1", "Bank 2"]
-# - product: filters a list of product you want if a subproduct is needed to filter, separated by a bullet (u'\u2022), i.e. [u"Mortgage\u2022FHA Mortgage", "Payday Loan"]
-# - issue: filters a list of issue you want if a subissue is needed to filter, separated by a bullet (u'\u2022), i.e. See Product above
+# - product: filters a list of product you want if a subproduct is needed to
+#   filter, separated by a bullet (u'\u2022), i.e.
+#   [u"Mortgage\u2022FHA Mortgage", "Payday Loan"]
+# - issue: filters a list of issue you want if a subissue is needed to filter,
+#   separated by a bullet (u'\u2022), i.e. See Product above
 # - state: filters a list of states you want
 # - zip_code: filters a list of zipcodes you want
-# - timely: filters a list of whether the company responds in a timely matter or not
+# - timely: filters a list of whether the company responds in a timely matter
+#   or not
 # - consumer_disputed: filters a list of dispute resolution
 # - company_response: filters a list of response from the company to consumer
 # - company_public_response: filters a list of public response from the company
-# - consumer_consent_provided: filters a list of whether consumer consent was provided in the complaint
+# - consumer_consent_provided: filters a list of whether consumer consent was
+#   provided in the complaint
 # - has_narrative: filters a list of whether complaint has narratives or not
 # - submitted_via: filters a list of ways the complaint was submitted
 # - tags - filters a list of tags
@@ -188,22 +202,31 @@ def search(agg_exclude=None, **kwargs):
         scroll_id = res['_scroll_id']
         if num_of_scroll > 0:
             while num_of_scroll > 0:
-                res['hits']['hits'] = _get_es().scroll(scroll_id=scroll_id,
-                                                       scroll="10m")['hits']['hits']
+                res['hits']['hits'] = _get_es().scroll(
+                    scroll_id=scroll_id,
+                    scroll="10m"
+                )['hits']['hits']
                 num_of_scroll -= 1
         res["_meta"] = _get_meta()
 
     elif format in EXPORT_FORMATS:
-        scanResponse = helpers.scan(client=_get_es(), query=body, scroll= "10m",
-                index=_COMPLAINT_ES_INDEX, size=7000, doc_type=_COMPLAINT_DOC_TYPE,
-                request_timeout=3000)
+        scanResponse = helpers.scan(
+            client=_get_es(),
+            query=body,
+            scroll="10m",
+            index=_COMPLAINT_ES_INDEX,
+            size=7000,
+            doc_type=_COMPLAINT_DOC_TYPE,
+            request_timeout=3000
+        )
 
         exporter = ElasticSearchExporter()
 
         if params.get("format") == 'csv':
             res = exporter.export_csv(
-                    scanResponse,
-                    CSV_ORDERED_HEADERS)
+                scanResponse,
+                CSV_ORDERED_HEADERS
+            )
         elif params.get("format") == 'json':
             del body['highlight']
             body['size'] = 0

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -1,30 +1,31 @@
-import os
-import json
 import copy
-import time
-from datetime import datetime, date, timedelta
-from collections import defaultdict, namedtuple
-import requests
+import json
 import logging
-from elasticsearch import Elasticsearch, helpers
-from flags.state import flag_enabled
-from complaint_search.es_builders import (
-    SearchBuilder,
-    PostFilterBuilder,
-    AggregationBuilder,
-)
+import os
+import time
+from collections import defaultdict, namedtuple
+from datetime import date, datetime, timedelta
+
+import requests
 from complaint_search.defaults import (
     CHUNK_SIZE,
     CSV_ORDERED_HEADERS,
     EXPORT_FORMATS,
     PARAMS,
 )
-from stream_content import (
+from complaint_search.es_builders import (
+    AggregationBuilder,
+    PostFilterBuilder,
+    SearchBuilder,
+)
+from complaint_search.export import ElasticSearchExporter
+from complaint_search.stream_content import (
     StreamCSVContent,
     StreamJSONContent,
 )
+from elasticsearch import Elasticsearch, helpers
+from flags.state import flag_enabled
 
-from export import ElasticSearchExporter
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'),
                               os.environ.get('ES_PORT', '9200'))

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -1,21 +1,16 @@
 import csv
 import json
-import os
 import six
 import sys
-from collections import OrderedDict
 from six import text_type
 from six.moves import cStringIO as StringIO
 
 from django.http import StreamingHttpResponse
 
-import elasticsearch
-from elasticsearch import Elasticsearch, helpers
-
 
 if six.PY2:
     # make sure no encode issues
-    reload(sys)
+    reload(sys)  # noqa: F821
     sys.setdefaultencoding('utf8')
 
 
@@ -28,7 +23,7 @@ class ElasticSearchExporter(object):
     #   The response from an Elasticsaerch scan query
     # - header_dict (OrderedDict)
     #   The ordered dictionary where the key is the Elasticsearch field name
-    #   and the value is the CSV column header for that field 
+    #   and the value is the CSV column header for that field
     def export_csv(self, scanResponse, header_dict):
         def read_and_flush(writer, buffer_, row):
             writer.writerow(row)
@@ -40,9 +35,9 @@ class ElasticSearchExporter(object):
 
         def stream():
             buffer_ = StringIO()
-            writer = csv.DictWriter(buffer_, header_dict.keys(), 
-                delimiter=",",quoting=csv.QUOTE_MINIMAL)
-            
+            writer = csv.DictWriter(buffer_, header_dict.keys(),
+                                    delimiter=",", quoting=csv.QUOTE_MINIMAL)
+
             # Write Header Row
             data = read_and_flush(writer, buffer_, header_dict)
             yield data
@@ -51,8 +46,11 @@ class ElasticSearchExporter(object):
             # Write CSV
             for row in scanResponse:
                 count += 1
-                rows_data = {key: text_type(value) for key, value in row['_source'].items()
-                             if key in header_dict.keys()}
+                rows_data = {
+                    key: text_type(value)
+                    for key, value in row['_source'].items()
+                    if key in header_dict.keys()
+                }
 
                 data = read_and_flush(writer, buffer_, rows_data)
                 yield data
@@ -62,7 +60,6 @@ class ElasticSearchExporter(object):
         )
         response['Content-Disposition'] = "attachment; filename=file.csv"
         return response
-
 
     # export_json - Stream an Elsticsearch response as a JSON file
     #

--- a/complaint_search/models.py
+++ b/complaint_search/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+# from django.db import models
 
 # Create your models here.

--- a/complaint_search/renderers.py
+++ b/complaint_search/renderers.py
@@ -1,7 +1,9 @@
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 
+
 class DefaultRenderer(JSONRenderer):
     format = 'default'
+
 
 class CSVRenderer(BaseRenderer):
     media_type = 'text/csv'

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -1,11 +1,11 @@
-from rest_framework import serializers
-from localflavor.us.us_states import STATE_CHOICES
 from complaint_search.defaults import PARAMS
+from localflavor.us.us_states import STATE_CHOICES
+from rest_framework import serializers
 
 
 class SearchInputSerializer(serializers.Serializer):
 
-    ### Format Choices
+    # Format Choices
     FORMAT_DEFAULT = 'default'
     FORMAT_JSON = 'json'
     FORMAT_CSV = 'csv'
@@ -16,7 +16,7 @@ class SearchInputSerializer(serializers.Serializer):
         (FORMAT_CSV, 'CSV'),
     )
 
-    ### Field Choices
+    # Field Choices
     FIELD_NARRATIVE = 'complaint_what_happened'
     FIELD_COMPANY = 'company'
     FIELD_ALL = 'all'
@@ -31,7 +31,7 @@ class SearchInputSerializer(serializers.Serializer):
         FIELD_ALL: '_all'
     }
 
-    ### Sort Choices
+    # Sort Choices
     SORT_RELEVANCE_DESC = 'relevance_desc'
     SORT_RELEVANCE_ASC = 'relevance_asc'
     SORT_CREATED_DATE_DESC = 'created_date_desc'
@@ -45,8 +45,12 @@ class SearchInputSerializer(serializers.Serializer):
     )
     format = serializers.ChoiceField(FORMAT_CHOICES, default=PARAMS['format'])
     field = serializers.ChoiceField(FIELD_CHOICES, default=PARAMS['field'])
-    size = serializers.IntegerField(min_value=0, max_value=10000000, default=PARAMS['size'])
-    frm = serializers.IntegerField(min_value=0, max_value=10000000, default=PARAMS['frm'])
+    size = serializers.IntegerField(
+        min_value=0, max_value=10000000, default=PARAMS['size']
+    )
+    frm = serializers.IntegerField(
+        min_value=0, max_value=10000000, default=PARAMS['frm']
+    )
     sort = serializers.ChoiceField(SORT_CHOICES, default=PARAMS['sort'])
     search_term = serializers.CharField(max_length=200, required=False)
     date_received_min = serializers.DateField(required=False)
@@ -62,7 +66,9 @@ class SearchInputSerializer(serializers.Serializer):
     state = serializers.ListField(
         child=serializers.ChoiceField(STATE_CHOICES), required=False)
     zip_code = serializers.ListField(
-        child=serializers.CharField(min_length=5, max_length=5), required=False)
+        child=serializers.CharField(
+            min_length=5, max_length=5), required=False
+    )
     timely = serializers.ListField(
         child=serializers.CharField(max_length=200), required=False)
     consumer_disputed = serializers.ListField(
@@ -85,7 +91,8 @@ class SearchInputSerializer(serializers.Serializer):
     def to_internal_value(self, data):
         ret = super(SearchInputSerializer, self).to_internal_value(data)
         if ret.get('field'):
-            ret['field'] = SearchInputSerializer.FIELD_MAP.get(ret['field'], ret['field'])
+            ret['field'] = SearchInputSerializer.FIELD_MAP.get(
+                ret['field'], ret['field'])
         return ret
 
     def validate_product(self, value):
@@ -97,7 +104,10 @@ class SearchInputSerializer(serializers.Serializer):
             for p in value:
                 # -*- coding: utf-8 -*-
                 if p.count(u'\u2022') > 1:
-                    raise serializers.ValidationError(u"Product is malformed, it needs to be \"product\" or \"product\u2022subproduct\"")
+                    raise serializers.ValidationError(
+                        u"Product is malformed, it needs to be \"product\" or "
+                        "\"product\u2022subproduct\""
+                    )
 
         return value
 
@@ -110,7 +120,10 @@ class SearchInputSerializer(serializers.Serializer):
             for p in value:
                 # -*- coding: utf-8 -*-
                 if p.count(u'\u2022') > 1:
-                    raise serializers.ValidationError(u"Issue is malformed, it needs to be \"issue\" or \"issue\u2022subissue\"")
+                    raise serializers.ValidationError(
+                        u"Issue is malformed, it needs to be \"issue\" or "
+                        "\"issue\u2022subissue\""
+                    )
 
         return value
 
@@ -119,13 +132,16 @@ class SearchInputSerializer(serializers.Serializer):
         Check that from is a multiple of size
         """
         if data['size'] != 0 and data['frm'] % data['size'] != 0:
-            raise serializers.ValidationError("frm is not zero or a multiple of size")
+            raise serializers.ValidationError(
+                "frm is not zero or a multiple of size")
         return data
 
 
 class SuggestInputSerializer(serializers.Serializer):
     text = serializers.CharField(max_length=200, required=False)
-    size = serializers.IntegerField(min_value=1, max_value=100000, required=False)
+    size = serializers.IntegerField(
+        min_value=1, max_value=100000, required=False
+    )
 
 
 class SuggestFilterInputSerializer(SearchInputSerializer):

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -8,12 +8,15 @@ class StreamCSVContent(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if self.header and not self.is_header_returned:
             self.is_header_returned = True
             return self.header
         else:
             return next(self.content)
+
+    def next(self):
+        return self.__next__()
 
 
 class StreamJSONContent(object):
@@ -50,7 +53,7 @@ class StreamJSONContent(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         while True:
             if not self.is_streaming_started:
                 # This is the beginning
@@ -79,3 +82,6 @@ class StreamJSONContent(object):
                     return "]"
                 else:
                     raise StopIteration
+
+    def next(self):
+        return self.__next__()

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -33,9 +33,9 @@ class StreamJSONContent(object):
         try:
             first_eol_index = self.complaint_in_progress.index('\n')
 
-            # see if we have 2nd completed line, and that's the complaint we want to return
-            # assuming at the EOF there's also a '\n' as seen from data format
-            # plugin so far
+            # see if we have 2nd completed line, and that's the complaint we
+            # want to return assuming at the EOF there's also a '\n' as seen
+            # from data format plugin so far
             second_eol_index = self.complaint_in_progress.index(
                 '\n', first_eol_index + 1)
 

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import copy
 from datetime import datetime
-from pprint import pprint
 
 from django.http import StreamingHttpResponse
 from django.test import TestCase
@@ -170,10 +169,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -205,10 +204,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -373,8 +372,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -401,8 +400,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -553,10 +552,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -580,10 +579,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -607,10 +606,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -634,10 +633,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -661,10 +660,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -688,10 +687,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -715,10 +714,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -742,10 +741,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -769,10 +768,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -798,8 +797,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -827,8 +826,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -856,8 +855,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -888,8 +887,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -916,8 +915,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -944,8 +943,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -972,11 +971,11 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        print(act_body)
-        print(body)
+        # print(act_body)
+        # print(body)
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1003,8 +1002,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1032,8 +1031,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1064,8 +1063,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1092,8 +1091,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1120,8 +1119,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1148,8 +1147,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1176,8 +1175,8 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
@@ -1204,10 +1203,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        if diff:
-            pprint(diff, indent=2)
+        # act_body = mock_search.call_args_list[0][1]['body']
+        # diff = DeepDiff(act_body, body)
+        # if diff:
+        #     pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -1,41 +1,27 @@
 from __future__ import unicode_literals
 
+import copy
+from datetime import datetime
+from pprint import pprint
+
 from django.http import StreamingHttpResponse
 from django.test import TestCase
+
+import mock
+from complaint_search.es_builders import AggregationBuilder, SearchBuilder
 from complaint_search.es_interface import (
-    _ES_URL,
-    _COMPLAINT_ES_INDEX,
     _COMPLAINT_DOC_TYPE,
-    _ES_USER,
-    _ES_PASSWORD,
     _get_meta,
+    document,
+    filter_suggest,
     search,
     suggest,
-    filter_suggest,
-    document
 )
-from complaint_search.es_builders import (
-    AggregationBuilder,
-    SearchBuilder
-)
-from complaint_search.export import (
-    ElasticSearchExporter
-)
-from complaint_search.defaults import (
-    CSV_ORDERED_HEADERS,
-)
-from complaint_search.stream_content import (
-    StreamCSVContent,
-    StreamJSONContent,
-)
-from datetime import datetime
-from elasticsearch import Elasticsearch
-from collections import namedtuple
-from nose_parameterized import parameterized
-import copy
-import mock
+from complaint_search.export import ElasticSearchExporter
 from deepdiff import DeepDiff
-from pprint import pprint
+from elasticsearch import Elasticsearch
+from nose_parameterized import parameterized
+
 
 # -------------------------------------------------------------------------
 # Helper Methods
@@ -147,7 +133,8 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch("complaint_search.es_interface.flag_enabled")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
-    def test_get_meta_data_issue(self, mock_count, mock_search, mock_flag_enabled, mock_now):
+    def test_get_meta_data_issue(
+            self, mock_count, mock_search, mock_flag_enabled, mock_now):
         mock_search.return_value = self.MOCK_SEARCH_SIDE_EFFECT[1]
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_now.return_value = datetime(2017, 1, 1)
@@ -164,7 +151,14 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_no_param__valid(self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_no_param__valid(
+        self,
+        mock_rget,
+        mock_scroll,
+        mock_count,
+        mock_search,
+        mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -192,7 +186,14 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_agg_exclude__valid(self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_agg_exclude__valid(
+        self,
+        mock_rget,
+        mock_scroll,
+        mock_count,
+        mock_search,
+        mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -218,13 +219,14 @@ class EsInterfaceTest_Search(TestCase):
     # @mock.patch("complaint_search.es_interface._ES_USER", "ES_USER")
     # @mock.patch("complaint_search.es_interface._ES_PASSWORD", "ES_PASSWORD")
     # @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    # @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE", "DOC_TYPE")
+    # @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
+    # "DOC_TYPE")
     # @mock.patch.object(Elasticsearch, 'search')
     # @mock.patch('requests.Session.get')
     # @mock.patch('json.dumps')
     # @mock.patch('urllib.urlencode')
     # def test_search_with_format_json__valid(self, mock_urlencode,
-    #                                         mock_jdump, mock_rget, mock_search):
+    #         mock_jdump, mock_rget, mock_search):
     #     mock_search.return_value = 'OK'
     #     mock_jdump.return_value = 'JDUMPS_OK'
     #     RGet = namedtuple('RGet', 'ok, iter_content')
@@ -265,12 +267,14 @@ class EsInterfaceTest_Search(TestCase):
     # @mock.patch("complaint_search.es_interface._ES_USER", "ES_USER")
     # @mock.patch("complaint_search.es_interface._ES_PASSWORD", "ES_PASSWORD")
     # @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    # @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE", "DOC_TYPE")
+    # @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
+    # "DOC_TYPE")
     # @mock.patch.object(Elasticsearch, 'search')
     # @mock.patch('requests.Session.get')
     # @mock.patch('json.dumps')
     # @mock.patch('urllib.urlencode')
-    # def test_search_with_format_csv__valid(self, mock_urlencode, mock_jdump, mock_rget, mock_search):
+    # def test_search_with_format_csv__valid(
+    #         self, mock_urlencode, mock_jdump, mock_rget, mock_search):
     #     mock_search.return_value = 'OK'
     #     mock_jdump.return_value = 'JDUMPS_OK'
     #     RGet = namedtuple('RGet', 'ok, iter_content')
@@ -282,7 +286,7 @@ class EsInterfaceTest_Search(TestCase):
     #     expected_res = 'RGET_OK'
 
     #     expected_header = ",".join('"' + header + '"'
-    #                                for header in CSV_ORDERED_HEADERS.values()) + "\n"
+    #         for header in CSV_ORDERED_HEADERS.values()) + "\n"
     #     self.assertTrue(isinstance(res, StreamCSVContent))
     #     self.assertEqual(res.header, expected_header)
     #     self.assertEqual(res.content, 'RGET_OK')
@@ -311,7 +315,6 @@ class EsInterfaceTest_Search(TestCase):
     #     mock_search.assert_not_called()
     #     self.assertEqual(1, mock_rget.call_count)
 
-
     @parameterized.expand([
         ['csv'],
         ['json']
@@ -320,7 +323,14 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(ElasticSearchExporter, 'export_json')
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch('elasticsearch.helpers.scan')
-    def test_search_with_format__valid(self, export_type, mock_es_helper, mock_search, mock_exporter_json, mock_exporter_csv):
+    def test_search_with_format__valid(
+        self,
+        export_type,
+        mock_es_helper,
+        mock_search,
+        mock_exporter_json,
+        mock_exporter_csv
+    ):
         mock_search_side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_search_side_effect[0]['hits']['total'] = 4
         mock_search.side_effect = mock_search_side_effect
@@ -345,7 +355,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_field__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_field__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -373,7 +385,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_field_all__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_field_all__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -408,7 +422,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_size__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_size__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -419,7 +435,6 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -430,13 +445,15 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_size_corrected__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_size_corrected__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
             self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_size_corrected__valid")
-        res = search(size=500)
+        load("search_with_size_corrected__valid")
+        search(size=500)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         self.assertEqual(100, mock_search.call_args_list[0][1]['body']['size'])
         mock_scroll.assert_not_called()
@@ -446,7 +463,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_frm__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_frm__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -458,7 +477,6 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         self.assertEqual(mock_scroll.call_count, 2)
@@ -472,7 +490,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_sort__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_sort__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
 
         sort_fields = [
             ("relevance_desc", "_score", "desc"),
@@ -486,20 +506,30 @@ class EsInterfaceTest_Search(TestCase):
         # mock_count.side_effect = []
         # for i in range(4):
 
-        mock_search.side_effect = [copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT[0])
-                                   for i in range(4)]
+        mock_search.side_effect = [
+            copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT[0])
+            for i in range(4)
+        ]
 
-        mock_count.side_effect = [copy.deepcopy(self.MOCK_COUNT_RETURN_VALUE)
-                                  for i in range(4)]
-        mock_get_meta.side_effect = [copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
-                                     for i in range(4)]
+        mock_count.side_effect = [
+            copy.deepcopy(self.MOCK_COUNT_RETURN_VALUE)
+            for i in range(4)
+        ]
+        mock_get_meta.side_effect = [
+            copy.deepcopy(self.MOCK_SEARCH_RESULT["_meta"])
+            for i in range(4)
+        ]
         body = load("search_with_sort__valid")
 
         for s in sort_fields:
             res = search(sort=s[0])
             body["sort"] = [{s[1]: {"order": s[2]}}]
             mock_search.assert_any_call(
-                body=body, index="INDEX", doc_type=_COMPLAINT_DOC_TYPE, scroll="10m")
+                body=body,
+                index="INDEX",
+                doc_type=_COMPLAINT_DOC_TYPE,
+                scroll="10m"
+            )
             self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
         mock_scroll.assert_not_called()
@@ -510,7 +540,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_match__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_search_term_match__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -535,7 +567,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_and__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_search_term_qsq_and__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -560,7 +594,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_or__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_search_term_qsq_or__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -585,7 +621,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_not__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_search_term_qsq_not__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -610,7 +648,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_to__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_search_term_qsq_to__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -635,7 +675,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_date_received_min__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_date_received_min__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -660,7 +702,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_date_received_max__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_date_received_max__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -685,7 +729,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_received_min__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_company_received_min__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -710,7 +756,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_received_max__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_company_received_max__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -735,7 +783,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_company__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -761,7 +811,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_agg_exclude__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_company_agg_exclude__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -788,13 +840,16 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_product__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_product__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
             self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_product__valid")
-        res = search([u"zip_code", u"company"], product=["Payday loan", u"Mortgage\u2022FHA mortgage"])
+        res = search([u"zip_code", u"company"],
+                     product=["Payday loan", u"Mortgage\u2022FHA mortgage"])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -814,14 +869,19 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_issue__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_issue__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
             self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_issue__valid")
-        res = search([u"zip_code", u"company"], issue=[u"Communication tactics\u2022Frequent or repeated calls",
-                            "Loan servicing, payments, escrow account"])
+        res = search(
+            [u"zip_code", u"company"],
+            issue=[u"Communication tactics\u2022Frequent or repeated calls",
+                   "Loan servicing, payments, escrow account"]
+        )
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -841,7 +901,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_state__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_state__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -867,7 +929,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_zip_code__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_zip_code__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -893,7 +957,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_zip_code_agg_exclude__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_zip_code_agg_exclude__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -922,7 +988,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_timely__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_timely__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -948,7 +1016,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_response__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_company_response__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -975,14 +1045,19 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_public_response__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_company_public_response__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
             self.MOCK_SEARCH_RESULT["_meta"])
         body = load("search_with_company_public_response__valid")
-        res = search(company_public_response=["Company chooses not to provide a public response",
-                                              "Company believes it acted appropriately as authorized by contract or law"])
+        res = search(company_public_response=[
+            "Company chooses not to provide a public response",
+            "Company believes it acted appropriately as authorized by "
+            "contract or law"
+        ])
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -1002,7 +1077,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_consumer_consent_provided__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_consumer_consent_provided__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -1028,7 +1105,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_submitted_via__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_submitted_via__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -1054,7 +1133,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_tags__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_tags__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -1080,7 +1161,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_has_narrative__valid(self, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_with_has_narrative__valid(
+        self, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -1107,7 +1190,9 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(Elasticsearch, 'count')
     @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_no_highlight__valid(self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta):
+    def test_search_no_highlight__valid(
+        self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta
+    ):
         mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
         mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
         mock_get_meta.return_value = copy.deepcopy(
@@ -1151,7 +1236,6 @@ class EsInterfaceTest_Suggest(TestCase):
                 }
             ]
         }
-        body = {}
         res = suggest()
         mock_suggest.assert_not_called()
         self.assertEqual([], res)
@@ -1181,7 +1265,6 @@ class EsInterfaceTest_Suggest(TestCase):
         self.assertEqual(len(mock_suggest.call_args), 2)
         self.assertEqual(0, len(mock_suggest.call_args[0]))
         self.assertEqual(2, len(mock_suggest.call_args[1]))
-        act_body = mock_suggest.call_args[1]['body']
         self.assertDictEqual(mock_suggest.call_args[1]['body'], body)
         self.assertEqual(mock_suggest.call_args[1]['index'], 'INDEX')
         self.assertEqual(['test 1', 'test 2'], res)
@@ -1211,7 +1294,6 @@ class EsInterfaceTest_Suggest(TestCase):
         self.assertEqual(len(mock_suggest.call_args), 2)
         self.assertEqual(0, len(mock_suggest.call_args[0]))
         self.assertEqual(2, len(mock_suggest.call_args[1]))
-        act_body = mock_suggest.call_args[1]['body']
         self.assertDictEqual(mock_suggest.call_args[1]['body'], body)
         self.assertEqual(mock_suggest.call_args[1]['index'], 'INDEX')
         self.assertEqual(['test 1', 'test 2'], res)
@@ -1273,7 +1355,11 @@ class EsInterfaceTest_FilterSuggest(TestCase):
         mock_builder2.return_value = agg
 
         actual = filter_suggest(
-            'company.suggest', display_field='company.raw', text='BA', company='company 1')
+            'company.suggest',
+            display_field='company.raw',
+            text='BA',
+            company='company 1'
+        )
 
         mock_search.assert_called_once_with(
             body={
@@ -1378,7 +1464,8 @@ class EsInterfaceTest_FilterSuggest(TestCase):
 class EsInterfaceTest_Document(TestCase):
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE", "DOC_TYPE")
+    @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
+                "DOC_TYPE")
     @mock.patch.object(Elasticsearch, 'search')
     def test_document__valid(self, mock_search):
         mock_search.return_value = 'OK'
@@ -1387,7 +1474,6 @@ class EsInterfaceTest_Document(TestCase):
         self.assertEqual(len(mock_search.call_args), 2)
         self.assertEqual(0, len(mock_search.call_args[0]))
         self.assertEqual(3, len(mock_search.call_args[1]))
-        act_body = mock_search.call_args[1]['body']
         self.assertDictEqual(mock_search.call_args[1]['body'], body)
         self.assertEqual(mock_search.call_args[1]['doc_type'], 'DOC_TYPE')
         self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.http import StreamingHttpResponse
 from django.test import TestCase
 from complaint_search.es_interface import (
@@ -31,8 +33,9 @@ from elasticsearch import Elasticsearch
 from collections import namedtuple
 from nose_parameterized import parameterized
 import copy
-import deep
 import mock
+from deepdiff import DeepDiff
+from pprint import pprint
 
 # -------------------------------------------------------------------------
 # Helper Methods
@@ -174,9 +177,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -202,9 +205,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -326,7 +329,7 @@ class EsInterfaceTest_Search(TestCase):
         mock_exporter_json.return_value = StreamingHttpResponse()
 
         res = search(format=export_type)
-        
+
         self.assertIsInstance(res, StreamingHttpResponse)
         self.assertEqual(1, mock_es_helper.call_count)
         if export_type == 'csv':
@@ -357,10 +360,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
         self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
@@ -383,11 +386,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
         self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
@@ -520,9 +522,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -545,9 +547,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -570,9 +572,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -595,9 +597,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -620,9 +622,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -645,9 +647,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -670,9 +672,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -695,9 +697,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -720,9 +722,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -745,10 +747,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -772,11 +774,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -799,10 +800,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -826,10 +827,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -852,10 +853,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -878,11 +879,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -906,11 +906,12 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        print(act_body)
+        print(body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -933,10 +934,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -960,10 +961,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -987,10 +988,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -1013,10 +1014,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -1039,10 +1040,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -1065,10 +1066,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -1091,10 +1092,10 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
-        self.assertIsNone(deep.diff(act_body, body))
+            pprint(diff, indent=2)
+        self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()
@@ -1119,9 +1120,9 @@ class EsInterfaceTest_Search(TestCase):
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
         self.assertEqual(4, len(mock_search.call_args_list[0][1]))
         act_body = mock_search.call_args_list[0][1]['body']
-        diff = deep.diff(act_body, body)
+        diff = DeepDiff(act_body, body)
         if diff:
-            diff.print_full()
+            pprint(diff, indent=2)
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
         mock_scroll.assert_not_called()

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 import io
 import json
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict, namedtuple
+
 from django.http import StreamingHttpResponse
 from django.test import TestCase
-from nose_parameterized import parameterized
 
 from complaint_search.export import ElasticSearchExporter
+from nose_parameterized import parameterized
 
 
 TEST_HEADERS = OrderedDict([
@@ -50,9 +51,9 @@ class ExportTest(TestCase):
 
         # mock_search.assert_not_called()
         self.assertEqual(res.get('Content-Disposition'), "attachment; filename=file.csv")
-        self.assertTrue('itertools.imap' in str(type(res.streaming_content)))
+        self.assertTrue('map' in str(type(res.streaming_content)))
         downloaded_file = io.BytesIO(b"".join(res.streaming_content))
-        self.assertTrue(not downloaded_file == None)
+        self.assertFalse(downloaded_file == None)
 
 
     @parameterized.expand([
@@ -73,7 +74,6 @@ class ExportTest(TestCase):
 
         # mock_search.assert_not_called()
         self.assertEqual(res.get('Content-Disposition'), "attachment; filename=file.json")
-        self.assertTrue('itertools.imap' in str(type(res.streaming_content)))
+        self.assertTrue('map' in str(type(res.streaming_content)))
         downloaded_file = io.BytesIO(b"".join(res.streaming_content))
-        self.assertTrue(not downloaded_file == None)
-
+        self.assertFalse(downloaded_file == None)

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import io
-import json
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 
 from django.http import StreamingHttpResponse
 from django.test import TestCase
@@ -18,11 +17,12 @@ TEST_HEADERS = OrderedDict([
     ("fourth_entry", "Fourth Entry"),
 ])
 
+
 def es_generator(n):
     count = 0
     while count < n:
         yield {
-            '_source':  {
+            '_source': {
                 'first_entry': 'Random 1',
                 'second_entry': 'Random 2',
                 'third_entry': 'Random 3',
@@ -30,7 +30,7 @@ def es_generator(n):
             }
         }
         count += 1
-    
+
 
 class ExportTest(TestCase):
     @parameterized.expand([
@@ -42,7 +42,7 @@ class ExportTest(TestCase):
         # arrange
         es_exporter = ElasticSearchExporter()
         gen = es_generator(length)
-        
+
         # act
         res = es_exporter.export_csv(gen, TEST_HEADERS)
 
@@ -50,11 +50,12 @@ class ExportTest(TestCase):
         self.assertTrue(isinstance(res, StreamingHttpResponse))
 
         # mock_search.assert_not_called()
-        self.assertEqual(res.get('Content-Disposition'), "attachment; filename=file.csv")
+        self.assertEqual(
+            res.get('Content-Disposition'), "attachment; filename=file.csv"
+        )
         self.assertTrue('map' in str(type(res.streaming_content)))
         downloaded_file = io.BytesIO(b"".join(res.streaming_content))
-        self.assertFalse(downloaded_file == None)
-
+        self.assertFalse(downloaded_file is None)
 
     @parameterized.expand([
         [10],
@@ -65,7 +66,7 @@ class ExportTest(TestCase):
         # arrange
         es_exporter = ElasticSearchExporter()
         gen = es_generator(length)
-        
+
         # act
         res = es_exporter.export_json(gen, length)
 
@@ -73,7 +74,9 @@ class ExportTest(TestCase):
         self.assertTrue(isinstance(res, StreamingHttpResponse))
 
         # mock_search.assert_not_called()
-        self.assertEqual(res.get('Content-Disposition'), "attachment; filename=file.json")
+        self.assertEqual(
+            res.get('Content-Disposition'), "attachment; filename=file.json"
+        )
         self.assertTrue('map' in str(type(res.streaming_content)))
         downloaded_file = io.BytesIO(b"".join(res.streaming_content))
-        self.assertFalse(downloaded_file == None)
+        self.assertFalse(downloaded_file is None)

--- a/complaint_search/tests/test_serializer.py
+++ b/complaint_search/tests/test_serializer.py
@@ -1,8 +1,11 @@
 # Most of the serializer code has been tested through the views
 import copy
+
 from django.test import TestCase
+
 from complaint_search.defaults import PARAMS
 from complaint_search.serializer import SearchInputSerializer
+
 
 class SearchInputSerializerTests(TestCase):
 
@@ -17,7 +20,7 @@ class SearchInputSerializerTests(TestCase):
         exp_dict = copy.deepcopy(PARAMS)
 
         # This is an OrderedDict
-        for k, v in serializer.validated_data.iteritems():
+        for k, v in serializer.validated_data.items():
 
             self.assertIn(k, exp_dict)
             self.assertEqual(v, exp_dict[k])
@@ -43,7 +46,3 @@ class SearchInputSerializerTests(TestCase):
         serializer = SearchInputSerializer(data=self.data)
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors.get('issue'), [u'Issue is malformed, it needs to be "issue" or "issue\u2022subissue"'])
-
-
-
-

--- a/complaint_search/tests/test_serializer.py
+++ b/complaint_search/tests/test_serializer.py
@@ -31,10 +31,17 @@ class SearchInputSerializerTests(TestCase):
         self.assertTrue(serializer.is_valid())
 
     def test_is_valid__invalid_product(self):
-        self.data['product'] = [u"Mortgage\u2022FHA Mortgage", "Payday Loan", u"Test\u2022Test\u2022"]
+        self.data['product'] = [
+            u"Mortgage\u2022FHA Mortgage",
+            "Payday Loan",
+            u"Test\u2022Test\u2022"
+        ]
         serializer = SearchInputSerializer(data=self.data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors.get('product'), [u'Product is malformed, it needs to be "product" or "product\u2022subproduct"'])
+        self.assertEqual(serializer.errors.get('product'), [
+            u'Product is malformed, it needs to be "product" or '
+            '"product\u2022subproduct"'
+        ])
 
     def test_is_valid__valid_issue(self):
         self.data['issue'] = [u"Test Issue\u2022Sub issue", "Issue 2"]
@@ -42,7 +49,14 @@ class SearchInputSerializerTests(TestCase):
         self.assertTrue(serializer.is_valid())
 
     def test_is_valid__invalid_issue(self):
-        self.data['issue'] = [u"Test Issue\u2022Sub issue", "Issue 2", u"Test\u2022Test\u2022"]
+        self.data['issue'] = [
+            u"Test Issue\u2022Sub issue",
+            "Issue 2",
+            u"Test\u2022Test\u2022"
+        ]
         serializer = SearchInputSerializer(data=self.data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors.get('issue'), [u'Issue is malformed, it needs to be "issue" or "issue\u2022subissue"'])
+        self.assertEqual(serializer.errors.get('issue'), [
+            u'Issue is malformed, it needs to be "issue" or '
+            '"issue\u2022subissue"'
+        ])

--- a/complaint_search/tests/test_stream_content.py
+++ b/complaint_search/tests/test_stream_content.py
@@ -29,12 +29,15 @@ class StreamCSVContentTests(TestCase):
 class StreamJSONContentTests(TestCase):
 
     def setUp(self):
-        self.content = '{"index": {"_index": "test", "_id": 12345}}\n' \
-            '{"product": "mortgage", "complaint_id": 12345, "tags": null}\n' \
-            '{"index": {"_index": "test", "_id": 23456}}\n' \
-            '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"}\n' \
-            '{"index": {"_index": "test", "_id": 45678}}\n' \
-            '{"product": "loan", "complaint_id": 45678, "tags": null} \n' \
+        self.content = (
+            '{"index": {"_index": "test", "_id": 12345}}\n'
+            '{"product": "mortgage", "complaint_id": 12345, "tags": null}\n'
+            '{"index": {"_index": "test", "_id": 23456}}\n'
+            '{"product": "test", "complaint_id": 23456, '
+            '"tags": "Older Americans"}\n'
+            '{"index": {"_index": "test", "_id": 45678}}\n'
+            '{"product": "loan", "complaint_id": 45678, "tags": null} \n'
+        )
 
         # pretend this is broken up randomly every 20 chars
         self.content_list = [self.content[(i * 20):(i * 20 + 20)]
@@ -53,7 +56,11 @@ class StreamJSONContentTests(TestCase):
             for json_in_progress in sc:
                 result += json_in_progress
 
-            exp_result = '[{"product": "mortgage", "complaint_id": 12345, "tags": null},' \
-                '{"product": "test", "complaint_id": 23456, "tags": "Older Americans"},' \
+            exp_result = (
+                '[{"product": "mortgage", "complaint_id": 12345, '
+                '"tags": null},'
+                '{"product": "test", "complaint_id": 23456, '
+                '"tags": "Older Americans"},'
                 '{"product": "loan", "complaint_id": 45678, "tags": null}]'
+            )
             self.assertEqual(exp_result, result)

--- a/complaint_search/tests/test_stream_content.py
+++ b/complaint_search/tests/test_stream_content.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from complaint_search.stream_content import (
     StreamCSVContent,
     StreamJSONContent,
@@ -37,7 +38,7 @@ class StreamJSONContentTests(TestCase):
 
         # pretend this is broken up randomly every 20 chars
         self.content_list = [self.content[(i * 20):(i * 20 + 20)]
-                             for i in range(len(self.content) / 20 + 1)]
+                             for i in range(int(len(self.content) / 20 + 1))]
 
     def test_iter(self):
         sc = StreamJSONContent(iter(self.content_list))
@@ -46,7 +47,7 @@ class StreamJSONContentTests(TestCase):
     def test_next_complete(self):
         for size in range(1, 1024):
             content_list = [self.content[(i * size):(i * size + size)]
-                            for i in range(len(self.content) / size + 1)]
+                            for i in range(int(len(self.content) / size + 1))]
             sc = StreamJSONContent(iter(content_list))
             result = ""
             for json_in_progress in sc:

--- a/complaint_search/tests/test_view_suggest_company.py
+++ b/complaint_search/tests/test_view_suggest_company.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
+
+import mock
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
-from elasticsearch import TransportError
-import mock
-from complaint_search.es_interface import filter_suggest
 
 
 class SuggestCompanyTests(APITestCase):

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -1,15 +1,11 @@
-from django.core.urlresolvers import reverse
 from django.core.cache import cache
+from django.core.urlresolvers import reverse
+
+import mock
+from complaint_search.throttling import _CCDB_UI_URL, DocumentAnonRateThrottle
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
-from unittest import skip
-from elasticsearch import TransportError
-import mock
-from complaint_search.es_interface import document
-from complaint_search.throttling import (
-    DocumentAnonRateThrottle,
-    _CCDB_UI_URL,
-)
 
 
 class DocumentTests(APITestCase):

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -1,14 +1,13 @@
-from django.core.urlresolvers import reverse
+import copy
+from datetime import date, datetime
+from unittest import skip
+
 from django.conf import settings
 from django.core.cache import cache
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse, StreamingHttpResponse
-from rest_framework import status
-from rest_framework.test import APITestCase
-from unittest import skip
-import copy
+
 import mock
-from datetime import date, datetime
-from elasticsearch import TransportError
 from complaint_search.defaults import (
     AGG_EXCLUDE_FIELDS,
     FORMAT_CONTENT_TYPE_MAP,
@@ -17,11 +16,15 @@ from complaint_search.defaults import (
 from complaint_search.es_interface import search
 from complaint_search.serializer import SearchInputSerializer
 from complaint_search.throttling import (
-    SearchAnonRateThrottle,
-    ExportUIRateThrottle,
-    ExportAnonRateThrottle,
     _CCDB_UI_URL,
+    ExportAnonRateThrottle,
+    ExportUIRateThrottle,
+    SearchAnonRateThrottle,
 )
+from elasticsearch import TransportError
+from rest_framework import status
+from rest_framework.test import APITestCase
+
 
 class SearchTests(APITestCase):
 
@@ -76,7 +79,7 @@ class SearchTests(APITestCase):
         """
         Searching with format
         """
-        for k, v in FORMAT_CONTENT_TYPE_MAP.iteritems():
+        for k, v in FORMAT_CONTENT_TYPE_MAP.items():
             url = reverse('complaint_search:search')
             params = {"format": k}
             mock_essearch.return_value = 'OK'

--- a/complaint_search/tests/test_views_suggest.py
+++ b/complaint_search/tests/test_views_suggest.py
@@ -1,11 +1,10 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
+
+import mock
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
-from unittest import skip
-from elasticsearch import TransportError
-import mock
-from complaint_search.es_interface import suggest
 
 
 class SuggestTests(APITestCase):

--- a/complaint_search/tests/test_views_suggest_company.py
+++ b/complaint_search/tests/test_views_suggest_company.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
+
+import mock
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
-from elasticsearch import TransportError
-import mock
-from complaint_search.es_interface import filter_suggest
 
 
 class SuggestCompanyTests(APITestCase):

--- a/complaint_search/tests/test_views_suggest_zip.py
+++ b/complaint_search/tests/test_views_suggest_zip.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
+
+import mock
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
-from elasticsearch import TransportError
-import mock
-from complaint_search.es_interface import filter_suggest
 
 
 class SuggestZipTests(APITestCase):

--- a/complaint_search/throttling.py
+++ b/complaint_search/throttling.py
@@ -1,29 +1,38 @@
 import os
-from rest_framework.throttling import AnonRateThrottle
-from complaint_search.defaults import EXPORT_FORMATS
 
-_CCDB_UI_URL = os.environ.get('CCDB_UI_URL', 
-    'http://localhost:8000/data-research/consumer-complaints/search')
+from complaint_search.defaults import EXPORT_FORMATS
+from rest_framework.throttling import AnonRateThrottle
+
+
+_CCDB_UI_URL = os.environ.get(
+    'CCDB_UI_URL',
+    'http://localhost:8000/data-research/consumer-complaints/search'
+)
+
 
 class CCDBRateThrottle(AnonRateThrottle):
     scope = 'ccdb'
 
-    def is_referred_from_ui(self, request,view):
+    def is_referred_from_ui(self, request, view):
         return request.META.get('HTTP_REFERER') and \
             request.META.get('HTTP_REFERER').find(_CCDB_UI_URL) != -1
 
-    def is_export(self, request): # otherwise it is a search
+    def is_export(self, request):  # otherwise it is a search
         return request.query_params.get("format") and \
             request.query_params.get("format") in EXPORT_FORMATS
-  
+
+
 class CCDBAnonRateThrottle(CCDBRateThrottle):
     scope = 'ccdb_anon'
 
     def allow_request(self, request, view):
         if not self.is_referred_from_ui(request, view):
-            return super(CCDBAnonRateThrottle, self).allow_request(request, view)
+            return super(CCDBAnonRateThrottle, self).allow_request(
+                request, view
+            )
         else:
             return True
+
 
 class CCDBUIRateThrottle(CCDBRateThrottle):
     scope = 'ccdb_ui'
@@ -40,9 +49,11 @@ class CCDBUIRateThrottle(CCDBRateThrottle):
 
 #     def allow_request(self, request, view):
 #         if not self.is_export(request):
-#             return super(SearchUIRateThrottle, self).allow_request(request, view)
+#             return super(SearchUIRateThrottle, self).allow_request(
+#                     request, view)
 #         else:
 #             return True
+
 
 class SearchAnonRateThrottle(CCDBAnonRateThrottle):
     scope = 'ccdb_anon_search'
@@ -50,9 +61,11 @@ class SearchAnonRateThrottle(CCDBAnonRateThrottle):
 
     def allow_request(self, request, view):
         if not self.is_export(request):
-            return super(SearchAnonRateThrottle, self).allow_request(request, view)
+            return super(SearchAnonRateThrottle, self).allow_request(
+                request, view)
         else:
             return True
+
 
 class ExportUIRateThrottle(CCDBUIRateThrottle):
     scope = 'ccdb_ui_export'
@@ -60,9 +73,11 @@ class ExportUIRateThrottle(CCDBUIRateThrottle):
 
     def allow_request(self, request, view):
         if self.is_export(request):
-            return super(ExportUIRateThrottle, self).allow_request(request, view)
+            return super(ExportUIRateThrottle, self).allow_request(
+                request, view)
         else:
             return True
+
 
 class ExportAnonRateThrottle(CCDBAnonRateThrottle):
     scope = 'ccdb_anon_export'
@@ -70,13 +85,16 @@ class ExportAnonRateThrottle(CCDBAnonRateThrottle):
 
     def allow_request(self, request, view):
         if self.is_export(request):
-            return super(ExportAnonRateThrottle, self).allow_request(request, view)
+            return super(ExportAnonRateThrottle, self).allow_request(
+                request, view)
         else:
             return True
+
 
 # class DocumentUIRateThrottle(CCDBUIRateThrottle):
 #     scope = 'ccdb_ui_document'
 #     # rate needs to be set if use
+
 
 class DocumentAnonRateThrottle(CCDBAnonRateThrottle):
     scope = 'ccdb_anon_document'

--- a/complaint_search/urls.py
+++ b/complaint_search/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url
+
 import complaint_search.views
+
 
 urlpatterns = [
     url(
@@ -13,6 +15,8 @@ urlpatterns = [
         name="suggest_zip"
     ),
     url(r'^_suggest', complaint_search.views.suggest, name="suggest"),
-    url(r'^(?P<id>[0-9]+)$', complaint_search.views.document, name="complaint"),
+    url(
+        r'^(?P<id>[0-9]+)$', complaint_search.views.document, name="complaint"
+    ),
     url(r'^$', complaint_search.views.search, name="search"),
 ]

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -118,7 +118,6 @@ def _buildHeaders():
 @catch_es_error
 def search(request):
 
-    fixed_qparam = request.query_params
     data = _parse_query_params(request.query_params)
 
     # Add format to data

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -1,31 +1,36 @@
-from rest_framework import status
-from rest_framework.decorators import (
-    api_view, renderer_classes, throttle_classes
-)
-from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
-from rest_framework.response import Response
-from django.http import StreamingHttpResponse
-from django.conf import settings
 from datetime import datetime
-import es_interface
+
+from django.conf import settings
+from django.http import StreamingHttpResponse
+
+from complaint_search import es_interface
+from complaint_search.decorators import catch_es_error
 from complaint_search.defaults import (
     AGG_EXCLUDE_FIELDS,
     EXPORT_FORMATS,
-    FORMAT_CONTENT_TYPE_MAP
+    FORMAT_CONTENT_TYPE_MAP,
 )
-from complaint_search.renderers import (
-    DefaultRenderer, CSVRenderer
-)
-from complaint_search.decorators import catch_es_error
+from complaint_search.renderers import CSVRenderer, DefaultRenderer
 from complaint_search.serializer import (
-    SearchInputSerializer, SuggestInputSerializer, SuggestFilterInputSerializer
+    SearchInputSerializer,
+    SuggestFilterInputSerializer,
+    SuggestInputSerializer,
 )
 from complaint_search.throttling import (
-    SearchAnonRateThrottle,
-    ExportUIRateThrottle,
-    ExportAnonRateThrottle,
     DocumentAnonRateThrottle,
+    ExportAnonRateThrottle,
+    ExportUIRateThrottle,
+    SearchAnonRateThrottle,
 )
+from rest_framework import status
+from rest_framework.decorators import (
+    api_view,
+    renderer_classes,
+    throttle_classes,
+)
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+from rest_framework.response import Response
+
 
 # -----------------------------------------------------------------------------
 # Query Parameters

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
-from setuptools import setup, find_packages
 from codecs import open
+
+from setuptools import find_packages, setup
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ testing_extras = [
     'coverage>=4.5.1,<5',
     'mock==2.0.0',
     'deep==0.10',
+    'deepdiff>=3.3,<5.0',
     'django-nose==1.4.1',
     'parameterized==0.6.1',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,45 @@
 [tox]
 skipsdist=True
-envlist=dj{111}
+envlist=py{27,36}-dj{111}
 
 [testenv]
+basepython=
+    py27: python2.7
+    py36: python3.6
+deps=
+    dj111: Django>=1.11,<1.12
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase
     coverage run manage.py test {posargs}
     coverage report
 
+[testenv:lint]
+basepython=python3.6
 deps=
-    dj111: Django>=1.11,<1.12
+    flake8
+    isort
+commands=
+    flake8 comparisontool
+    isort --check-only --diff --recursive comparisontool
+
+[flake8]
+ignore = E731, W503, W504,
+exclude =
+    .git,
+    .tox,
+    __pycache__,
+    */migrations/*.py,
+
+[isort]
+line_length=78
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_future_library=future,six
+known_third_party=mock
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{111}
+envlist=lint,py{27,36}-dj{111}
 
 [testenv]
 basepython=
@@ -20,8 +20,8 @@ deps=
     flake8
     isort
 commands=
-    flake8 comparisontool
-    isort --check-only --diff --recursive comparisontool
+    flake8 ccdb5_api complaint_search
+    isort --check-only --diff --recursive ccdb5_api complaint_search
 
 [flake8]
 ignore = E731, W503, W504,


### PR DESCRIPTION
There is an issue with the deep dependency, which isn't Python 3-compatible.

Still a work-in-progress. And there's linting to do.