### PR TITLE
Update Django REST Framework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 install_requires = [
     'Django>=1.11,<1.12',
-    'djangorestframework>=3.6,<3.9',
+    'djangorestframework>=3.6,<4.0',
     'requests>=2.18,<3',
     'elasticsearch>=2.4.1,<3',
     'django-localflavor>=1.1,<2',

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ skipsdist=True
 envlist=dj{111}
 
 [testenv]
+basepython=python2.7
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase


### PR DESCRIPTION
This PR addresses the vulnerability alert for Django REST Framework, bumping its version spec to >=3.6,<4.0.