### PR TITLE
Update .travis.yml to build a universal wheel file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - pip install coveralls
 script:
 - tox
-- python setup.py bdist_wheel
+- python setup.py bdist_wheel --universal
 after_success:
 - coveralls
 deploy:


### PR DESCRIPTION
This PR adds `--universal` to `bdist_wheel` so we have one wheel to rule all python versions.