### PR TITLE
Run the linter as part of Travis testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Python #
+#########
+.python-version
+
 # Django #
 #################
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
-- '2.7'
-- '3.6'
+- 2.7
+- 3.6
 install:
-- pip install tox-travis
-- pip install tox
-- pip install coveralls
+- pip install coveralls tox-travis
 script:
 - tox
 - python setup.py bdist_wheel --universal

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -1,7 +1,8 @@
-import csv
-import json
 from six import text_type
 from six.moves import cStringIO as StringIO
+
+import csv
+import json
 
 from django.http import StreamingHttpResponse
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ exclude =
 [isort]
 line_length=78
 include_trailing_comma=1
+lines_after_imports=2
 multi_line_output=3
 skip=.tox,migrations
 not_skip=__init__.py
@@ -43,3 +44,8 @@ known_future_library=future,six
 known_third_party=mock
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+[travis]
+python=
+  2.7: py27-dj111
+  3.6: py36-dj111, lint


### PR DESCRIPTION
This change adds the linter commands (flake8/isort) to the Travis CI configuration for this project.

To get the existing linter tests to pass, it sets `lines_after_imports=2`, which feels like a reasonable setting that we already have [in cfgov-refresh](https://github.com/cfpb/cfgov-refresh/blob/3f2d737506e777f7816a7a74c982c2edd065d985/.isort.cfg#L3).

This also adds .python-version to the .gitignore so that local configuration of pyenv doesn't get tracked by git.

You can see in [the Travis build for this PR](https://travis-ci.org/chosak/ccdb5-api/builds/554769413) that the Python 3 step ran both the linter and tests, while the Python 2 step ran only the tests, as intended. Compare that with [previous builds of this project](https://travis-ci.org/cfpb/ccdb5-api/builds/548837254) where the linter is never run.