### PR TITLE
Remove call to set default encoding to UTF-8

### DIFF
--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -1,17 +1,9 @@
 import csv
 import json
-import six
-import sys
 from six import text_type
 from six.moves import cStringIO as StringIO
 
 from django.http import StreamingHttpResponse
-
-
-if six.PY2:
-    # make sure no encode issues
-    reload(sys)  # noqa: F821
-    sys.setdefaultencoding('utf8')
 
 
 class ElasticSearchExporter(object):


### PR DESCRIPTION
This commit removes a call that sets the default string encoding used to UTF-8. This call happens when the complaint_search.export module is imported by the complaint_search.views module, which is in turn imported by the complaint_search.urls module, which is imported into cf.gov in the main cfgov-refresh urls.py.

This behavior is a little bit unexpected, because it means that the act of importing ccdb5-api URLs modifies your system default text encoding.

Also, this behavior causes [this](https://github.com/cfpb/cfgov-refresh/blob/3f2d737506e777f7816a7a74c982c2edd065d985/cfgov/v1/tests/handlers/blocks/test_feedback.py#L55) seemingly unrelated cfgov-refresh test to fail, because a "misencoded" string is now encodeable with a default string encoding.

@JeffreyMFarley suggested that this code might be here to support the "bullet" character used in CCDB URLs, [for example](https://www.consumerfinance.gov/data-research/consumer-complaints/search/?from=0&product=Mortgage%E2%80%A2Other%20mortgage&searchField=all&searchText=&size=25&sort=created_date_desc).

I tested this change locally and was able to confirm that I get the proper number of results when using a similar query [locally with the latest CCDB data](http://localhost:8000/data-research/consumer-complaints/search/?from=0&product=Mortgage%E2%80%A2Other%20mortgage&searchField=all&searchText=&size=25&sort=created_date_desc).

Additionally, all unit tests in this package continue to pass with this change.