### PR TITLE
Properly support Unicode in CSV exports

### DIFF
--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -1,3 +1,4 @@
+import six
 from six import text_type
 from six.moves import cStringIO as StringIO
 
@@ -5,6 +6,12 @@ import csv
 import json
 
 from django.http import StreamingHttpResponse
+
+
+if six.PY2:
+    from unicodecsv import DictWriter
+else:
+    from csv import DictWriter
 
 
 class ElasticSearchExporter(object):
@@ -28,8 +35,8 @@ class ElasticSearchExporter(object):
 
         def stream():
             buffer_ = StringIO()
-            writer = csv.DictWriter(buffer_, header_dict.keys(),
-                                    delimiter=",", quoting=csv.QUOTE_MINIMAL)
+            writer = DictWriter(buffer_, header_dict.keys(),
+                                delimiter=",", quoting=csv.QUOTE_MINIMAL)
 
             # Write Header Row
             data = read_and_flush(writer, buffer_, header_dict)

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -8,9 +8,9 @@ import json
 from django.http import StreamingHttpResponse
 
 
-if six.PY2:
+if six.PY2:  # pragma: no cover
     from unicodecsv import DictWriter
-else:
+else:  # pragma: no cover
     from csv import DictWriter
 
 

--- a/complaint_search/stream_content.py
+++ b/complaint_search/stream_content.py
@@ -1,3 +1,6 @@
+import six
+
+
 class StreamCSVContent(object):
 
     def __init__(self, header, content):
@@ -15,8 +18,9 @@ class StreamCSVContent(object):
         else:
             return next(self.content)
 
-    def next(self):
-        return self.__next__()
+    if six.PY2:  # pragma: no cover
+        def next(self):
+            return self.__next__()
 
 
 class StreamJSONContent(object):
@@ -83,5 +87,6 @@ class StreamJSONContent(object):
                 else:
                     raise StopIteration
 
-    def next(self):
-        return self.__next__()
+    if six.PY2:  # pragma: no cover
+        def next(self):
+            return self.__next__()

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -80,3 +80,22 @@ class ExportTest(TestCase):
         self.assertTrue('map' in str(type(res.streaming_content)))
         downloaded_file = io.BytesIO(b"".join(res.streaming_content))
         self.assertFalse(downloaded_file is None)
+
+
+class TestCSVExportWithUnicodeCharacters(TestCase):
+    def test_export_contains_unicode_chacter(self):
+        headers = OrderedDict([
+            ('key', 'Key'),
+        ])
+
+        def unicode_results():
+            yield {
+                '_source': {
+                    'key': u'\u2019',
+                },
+            }
+
+        exporter = ElasticSearchExporter()
+        response = exporter.export_csv(unicode_results(), headers)
+        content = io.BytesIO(b"".join(response.streaming_content)).read()
+        self.assertEqual(content, b'Key\r\n\xe2\x80\x99\r\n')

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'elasticsearch>=2.4.1,<3',
     'django-localflavor>=1.1,<2',
     'django-flags>=4.0.1,<5',
+    'unicodecsv>=0.14.1,<1',
 ]
 
 testing_extras = [


### PR DESCRIPTION
Results containing non-ASCII characters will currently cause encoding errors when a CSV export is triggered, which causes results to be cut off prematurely.

This is due to the change in #93 that removed use of a default UTF-8 encoding.

This fix adds use of the [unicodecsv](https://pypi.org/project/unicodecsv/) Python package (already in use in cfgov-refresh) so that exports work properly when using Python 2.

A new test has been added to verify this behavior.