### PR TITLE
Allow API requests from CFPB Github Pages

### DIFF
--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -90,7 +90,10 @@ def _parse_query_params(query_params, validVars=None):
 
 def _buildHeaders():
     # Local development requires CORS support
-    headers = {}
+    headers = {
+        'Access-Control-Allow-Origin': 'https://cfpb.github.io',
+        'Access-Control-Allow-Methods': 'GET'
+    }
     if settings.DEBUG:
         headers = {
             'Access-Control-Allow-Origin': '*',

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -86,14 +86,15 @@ def _parse_query_params(query_params, validVars=None):
 
 
 # -----------------------------------------------------------------------------
-# Header methods
+# Header methods TEST REMOVE ME
 
 def _buildHeaders():
-    # Local development requires CORS support
+    # API Documentation hosted on Github pages needs GET access
     headers = {
         'Access-Control-Allow-Origin': 'https://cfpb.github.io',
         'Access-Control-Allow-Methods': 'GET'
     }
+    # Local development requires CORS support
     if settings.DEBUG:
         headers = {
             'Access-Control-Allow-Origin': '*',

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -86,7 +86,7 @@ def _parse_query_params(query_params, validVars=None):
 
 
 # -----------------------------------------------------------------------------
-# Header methods TEST REMOVE ME
+# Header methods
 
 def _buildHeaders():
     # API Documentation hosted on Github pages needs GET access


### PR DESCRIPTION
Ensures that GET requests coming from API documentation pages controlled by the CFPB organization can access the content that they are requesting and provide full responses for users.