### PR TITLE
Remove BrowsableAPI as a renderer

### DIFF
--- a/ccdb5_api/tox.py
+++ b/ccdb5_api/tox.py
@@ -1,0 +1,28 @@
+import logging
+
+from .settings import *  # noqa
+
+
+logging.captureWarnings(True)
+
+
+# -----------------------------------------------------------------------------
+# Logging
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'CRITICAL',
+        },
+    },
+    'loggers': {
+        'complaint_search': {
+            'level': 'DEBUG',
+            'propagate': False,
+            'handlers': ['console'],
+        },
+    }
+}

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -1,8 +1,9 @@
-import csv
-import json
 import six
 from six import text_type
 from six.moves import cStringIO as StringIO
+
+import csv
+import json
 
 from django.http import StreamingHttpResponse
 

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -1,9 +1,8 @@
+import csv
+import json
 import six
 from six import text_type
 from six.moves import cStringIO as StringIO
-
-import csv
-import json
 
 from django.http import StreamingHttpResponse
 

--- a/complaint_search/tests/test_view_search_renderers.py
+++ b/complaint_search/tests/test_view_search_renderers.py
@@ -1,0 +1,35 @@
+from django.core.urlresolvers import reverse
+
+import mock
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+DEFAULT_ACCEPT = (
+    'text/html,application/xhtml+xml,application/xml;q=0.9,'
+    'image/webp,image/apng,*/*;q=0.8'
+)
+
+
+class SearchRendererTests(APITestCase):
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_no_format_chrome_request(self, mock_essearch):
+        expected = {'foo': 'bar'}
+        mock_essearch.return_value = expected
+
+        url = reverse('complaint_search:search')
+        response = self.client.get(url, HTTP_ACCEPT=DEFAULT_ACCEPT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(expected, response.data)
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_accept_html_only(self, mock_essearch):
+        expected = {'foo': 'bar'}
+        mock_essearch.return_value = expected
+        accept = 'text/html'
+
+        url = reverse('complaint_search:search')
+        response = self.client.get(url, HTTP_ACCEPT=accept)
+        self.assertEqual(response.status_code, 406)
+        self.assertEqual(response['Content-Type'], 'application/json')

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -28,7 +28,7 @@ from rest_framework.decorators import (
     renderer_classes,
     throttle_classes,
 )
-from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 
@@ -112,7 +112,6 @@ def _buildHeaders():
     DefaultRenderer,
     JSONRenderer,
     CSVRenderer,
-    BrowsableAPIRenderer,
 ))
 @throttle_classes([
     SearchAnonRateThrottle,

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,13 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
 install_command=pip install -e ".[testing]" -U {opts} {packages}
+setenv=
+    DJANGO_SETTINGS_MODULE=ccdb5_api.tox
 commands=
     coverage erase
     coverage run manage.py test {posargs}
     coverage report
+    coverage html
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
Work on #102

## Context

While it was nice getting the HTML view of a JSON endpoint, it gets in the way of the API having a simple default behavior.

When the user requests `search/api/v1/` without a format parameter, it is expected that the default format `json` is used and the content returned is of type `application/json`

However, if the request is coming from a browser, the `ACCEPT` header looks a little different

```
ACCEPT: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
```

The render classes would look at this string and return HTML (since it is listed before `*/*`) even though the default is 'json'

## The fix

I removed the `BrowsableAPI` renderer.  This shouldn't break functionality (since it was not documented).  If users of the API enjoyed the BrowsableAPI page, they may want to switch to using Postman or similar tools.

## Other fixes

Closes #100 
