### PR TITLE
Handle Size

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -198,8 +198,8 @@ def search(agg_exclude=None, **kwargs):
                                body=body,
                                scroll="10m")
 
-        if res['hits'['hits']:
-            num_of_scroll=params.get("frm") / body["size"]
+        if res['hits']['hits']:
+            num_of_scroll = params.get("frm") / body["size"]
             scroll_id = res['_scroll_id']
             if num_of_scroll > 0:
                 while num_of_scroll > 0:

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -198,15 +198,16 @@ def search(agg_exclude=None, **kwargs):
                                body=body,
                                scroll="10m")
 
-        num_of_scroll = params.get("frm") / body["size"]
-        scroll_id = res['_scroll_id']
-        if num_of_scroll > 0:
-            while num_of_scroll > 0:
-                res['hits']['hits'] = _get_es().scroll(
-                    scroll_id=scroll_id,
-                    scroll="10m"
-                )['hits']['hits']
-                num_of_scroll -= 1
+        if res['hits'['hits']:
+            num_of_scroll=params.get("frm") / body["size"]
+            scroll_id = res['_scroll_id']
+            if num_of_scroll > 0:
+                while num_of_scroll > 0:
+                    res['hits']['hits'] = _get_es().scroll(
+                        scroll_id=scroll_id,
+                        scroll="10m"
+                    )['hits']['hits']
+                    num_of_scroll -= 1
         res["_meta"] = _get_meta()
 
     elif format in EXPORT_FORMATS:


### PR DESCRIPTION
Similarly to #106, this change allows us to decouple calls to Elasticsearch for hits and aggregations:

* If the `size` parameter is provided as zero (`size=0`), the request made to Elasticsearch will not return matching complaints, but it will return aggregations with any filters applied.
* If the `no_aggs` parameter is provided as True (`no_aggs=true`) then the request made to Elasticsearch will return matching complaints, but will not return aggregations