### PR TITLE
Pin Django Rest Framework to >=3.9.1,<4.0

### DIFF
--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -21,6 +21,7 @@ from complaint_search.throttling import (
 )
 from elasticsearch import TransportError
 from rest_framework import status
+from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase
 
 
@@ -336,9 +337,12 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"date_received_min": [
-                "Date has wrong format. Use one of these formats instead: "
-                "YYYY[-MM[-DD]]."
+            {'date_received_min': [
+                ErrorDetail(
+                    string='Date has wrong format. Use one of these formats '
+                    'instead: YYYY-MM-DD.',
+                    code='invalid'
+                )
             ]},
             response.data
         )
@@ -368,9 +372,12 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"date_received_max": [
-                "Date has wrong format. Use one of these formats instead: "
-                "YYYY[-MM[-DD]]."
+            {'date_received_max': [
+                ErrorDetail(
+                    string='Date has wrong format. Use one of these formats '
+                    'instead: YYYY-MM-DD.',
+                    code='invalid'
+                )
             ]},
             response.data
         )
@@ -400,9 +407,11 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"company_received_min": [
-                "Date has wrong format. Use one of these formats instead: "
-                "YYYY[-MM[-DD]]."
+            {'company_received_min': [
+                ErrorDetail(
+                    string='Date has wrong format. Use one of these formats '
+                    'instead: YYYY-MM-DD.',
+                    code='invalid')
             ]},
             response.data
         )
@@ -433,8 +442,11 @@ class SearchTests(APITestCase):
         mock_essearch.assert_not_called()
         self.assertDictEqual(
             {"company_received_max": [
-                "Date has wrong format. Use one of these formats instead: "
-                "YYYY[-MM[-DD]]."
+                ErrorDetail(
+                    string="Date has wrong format. Use one of these formats "
+                    "instead: YYYY-MM-DD.",
+                    code='invalid'
+                )
             ]},
             response.data
         )
@@ -668,7 +680,9 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"no_aggs": [u'"Not boolean" is not a valid boolean.']},
+            {'no_aggs': [
+                ErrorDetail(string='Must be a valid boolean.', code='invalid')
+            ]},
             response.data
         )
 
@@ -695,7 +709,9 @@ class SearchTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"no_highlight": [u'"Not boolean" is not a valid boolean.']},
+            {'no_highlight': [
+                ErrorDetail(string='Must be a valid boolean.', code='invalid')
+            ]},
             response.data)
 
     @mock.patch('complaint_search.es_interface.search')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 install_requires = [
     'Django>=1.11,<1.12',
-    'djangorestframework>=3.6,<3.9',
+    'djangorestframework>=3.9.1,<4.0',
     'django-rest-swagger>=2.2.0',
     'requests>=2.18,<3',
     'elasticsearch>=2.4.1,<3',


### PR DESCRIPTION
This change will pin Django Rest Framework to >=3.9.1 to detail with a security issue that GitHub has flagged, and <4.0 which is the the exclusive maximum that Wagtail 2.8 currently pins (which we have to be compatible with when ccdb5-api gets pulled into cfgov-refresh).

There's some minor incompatibility between the previous version and more recents in terms of the way error dicts are returned. The error strings are now wrapped in `ErrorDetail`. This change also updates the tests as appropriate.