### PR TITLE
Fix "Tags" filter shows 0 results when two tags are selected

### DIFF
--- a/complaint_search/tests/expected_results/search_with_tags__valid.json
+++ b/complaint_search/tests/expected_results/search_with_tags__valid.json
@@ -33,22 +33,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -67,22 +63,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -101,22 +93,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -160,22 +148,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -194,22 +178,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -228,22 +208,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -262,22 +238,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -296,22 +268,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -330,22 +298,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -364,22 +328,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -406,22 +366,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -440,22 +396,18 @@
       "filter": {
         "bool": {
           "filter": [
-            [
-              {
-                "terms": {
-                  "tags": [
-                    "Older American"
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "tags": [
-                    "Servicemember"
-                  ]
+            {
+              "bool": {
+                "should": {
+                  "terms": {
+                    "tags": [
+                      "Older American",
+                      "Servicemember"
+                    ]
+                  }
                 }
               }
-            ]
+            }
           ],
           "should": [],
           "must": []
@@ -483,22 +435,18 @@
   "post_filter": {
     "bool": {
       "filter": [
-        [
-          {
-            "terms": {
-              "tags": [
-                "Older American"
-              ]
-            }
-          },
-          {
-            "terms": {
-              "tags": [
-                "Servicemember"
-              ]
+        {
+          "bool": {
+            "should": {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
             }
           }
-        ]
+        }
       ],
       "must": [],
       "should": []

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -1146,7 +1146,7 @@ class EsInterfaceTest_Search(TestCase):
         act_body = mock_search.call_args_list[0][1]['body']
         diff = DeepDiff(act_body, body)
         # if diff:
-        #     pprint(diff, indent=2)
+        #     print(diff)
         self.assertEqual(diff, {})
         self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
         self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -663,6 +663,25 @@ class SearchTests(APITestCase):
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
+    def test_search_with__multiple_tags__valid(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        url += "?tags=Older%20American%2C%20Servicemember"
+        url += "&tags=Older%20American"
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        # -*- coding: utf-8 -*-
+        mock_essearch.assert_called_once_with(
+            agg_exclude=AGG_EXCLUDE_FIELDS,
+            **self.buildDefaultParams({
+                "tags": [
+                    "Older American, Servicemember",
+                    "Older American"
+                ]})
+        )
+        self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
     def test_search_with_no_aggs__valid(self, mock_essearch):
         url = reverse('complaint_search:search')
         params = {"no_aggs": True}

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ setenv=
 commands=
     coverage erase
     coverage run manage.py test {posargs}
+commands_post=
     coverage report
     coverage html
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ setenv=
 commands=
     coverage erase
     coverage run manage.py test {posargs}
-commands_post=
     coverage report
     coverage html
 


### PR DESCRIPTION
## Current Behavior:
1. https://www.consumerfinance.gov/data-research/consumer-complaints/search/?from=0&searchField=all&searchText=&size=25&sort=created_date_desc&tags=Older%20American&tags=Servicemember
1. When a user selects two values from the "Tags" filter, 0 results are shown instead of the sum of their results.

## Changes

We changed how we index the tags filter, but we did not change the API, which treated them as boolean fields

## Testing

Pass with updated criteria