### PR TITLE
Update django-localflavor to 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ An API that provides an interface to search complaint data.
 
 ## Requirements
 
-Requirements are retrieved and/or build automatically via pip (see below).
+Requirements are batch-installed via pip (see below).
 
 * django - Web framework
-* djangolocalflavor - Country-specific Django helpers
+* django-localflavor - Country-specific Django helpers
 * djangorestframework - Rest API framework
 * elasticsearch - low level client for Elasticsearch
 * requests - http requests to get different data format

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An API that provides an interface to search complaint data.
 Requirements are retrieved and/or build automatically via pip (see below).
 
 * django - Web framework
+* djangolocalflavor - Country-specific Django helpers
 * djangorestframework - Rest API framework
 * elasticsearch - low level client for Elasticsearch
 * requests - http requests to get different data format

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'django-rest-swagger>=2.2.0',
     'requests>=2.18,<3',
     'elasticsearch>=2.4.1,<3',
-    'django-localflavor>=1.1,<3',
+    'django-localflavor>=1.1,<3.1',
     'django-flags>=4.0.1,<5',
     'unicodecsv>=0.14.1,<1',
 ]


### PR DESCRIPTION
Change version of `django-localflavor` to support version 3.0
This change will resolve the following in `cfgov-refresh`:
`ERROR: ccdb5-api 1.7.0 has requirement django-localflavor<3,>=1.1, but you'll have django-localflavor 3.0 which is incompatible.`

## Additions

- Include `djangolocalflavor` in `README.md`

## Changes

- Update version of `django-localflavor` to support 3.0 in `setup.py`

## Testing

1. tox -e lint
2. tox -e py36-dj111
3. tox -e py36-dj22

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: