### PR TITLE
Change the description of the "field" parameter

### DIFF
--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -289,7 +289,7 @@ components:
     field:
       name: field
       in: query
-      description: Search by particular field. If this parameter is not specified, default behavior will return only complaints with narratives.
+      description: If the parameter "search_term" has a value, use "field" to specify which field is searched. If not specified, "complaint_what_happened" will be searched.
       schema:
         type: string
         enum:


### PR DESCRIPTION
Closes #122 

The use of the `field` parameter is [here](https://github.com/cfpb/ccdb5-api/blob/master/complaint_search/es_builders.py#L216-L244)