### PR TITLE
Remove unicodecsv from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ install_requires = [
     'elasticsearch>=2.4.1,<3',
     'django-localflavor>=1.1,<3.1',
     'django-flags>=4.0.1,<5',
-    'unicodecsv>=0.14.1,<1',
 ]
 
 testing_extras = [


### PR DESCRIPTION
This package is no longer used in ccdb5.