### PR TITLE
Trends Focus

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -70,3 +70,10 @@ FORMAT_CONTENT_TYPE_MAP = {
     "json": "application/json",
     "csv": "text/csv",
 }
+
+DATA_SUB_LENS_MAP = {
+    'product': ('sub_product', 'issue', 'company', 'tags'),
+    'issue': ('product', 'sub_issue', 'company', 'tags'),
+    'company': ('product', 'issue', 'tags'),
+    'tags': ('product', 'issue', 'company'),
+}

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -494,7 +494,7 @@ class StateAggregationBuilder(BaseBuilder):
         for item in self.params:
             if item in (
                 self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ) and item not in self.exclude:
+            ):
                 field_level_should = {
                     "bool": {"should": self.filter_clauses[item]}
                 }

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -600,14 +600,12 @@ class LensAggregationBuilder(BaseBuilder):
 
 class TrendsAggregationBuilder(LensAggregationBuilder):
     _AGG_FIELDS = (
-        'company',
         'issue',
         'tags',
         'product'
     )
 
     _AGG_HEADING_MAP = {
-        'company': 'company',
         'issue': 'issue',
         'product': 'product',
         'sub_product': 'sub-product',
@@ -741,6 +739,8 @@ class TrendsAggregationBuilder(LensAggregationBuilder):
         # filter is selected
         if 'company' in self.params and 'company' in self.exclude:
             self.exclude.remove('company')
+            self._AGG_FIELDS + ('company',)
+            self._AGG_HEADING_MAP['company'] = 'company'
 
         aggs = {}
 
@@ -765,6 +765,10 @@ class TrendsAggregationBuilder(LensAggregationBuilder):
         elif 'focus' in self.params:
             for field_name in DATA_SUB_LENS_MAP.get(self.params['lens']) \
                     + (self.params['lens'], ):
+                if field_name == 'company' and 'company' not in self.params:
+                    # Do not include company agg unless there is a company
+                    # filter
+                    continue
                 agg_heading_name = self.get_agg_heading(field_name)
 
                 aggs[agg_heading_name] = self.build_one_focus(

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -1,4 +1,4 @@
-from complaint_search.defaults import PARAMS
+from complaint_search.defaults import PARAMS, DATA_SUB_LENS_MAP
 from localflavor.us.us_states import STATE_CHOICES
 from rest_framework import serializers
 
@@ -186,13 +186,8 @@ class TrendsInputSerializer(SearchInputSerializer):
         (TAGS, 'Tags Lens'),
     )
 
-    DATA_SUB_LENS_MAP = {
-        'product': ('sub_product', 'issue', 'company', 'tags'),
-        'issue': ('product', 'sub_issue', 'company', 'tags'),
-        'company': ('product', 'issue', 'tags'),
-        'tags': ('product', 'issue', 'company'),
-    }
-
+    focus = serializers.CharField(min_length=1, max_length=10000,
+                                  required=False)
     trend_interval = serializers.ChoiceField(INTERVAL_CHOICES)
     trend_depth = serializers.IntegerField(
         min_value=5, max_value=10000000, default=5
@@ -205,24 +200,23 @@ class TrendsInputSerializer(SearchInputSerializer):
                                      required=False)
 
     def validate(self, data):
-        # ret = super(SearchInputSerializer, self).to_internal_value(data)
-
-        if 'sub_lens' not in data \
+        if 'focus' not in data \
+           and 'sub_lens' not in data \
            and not data['lens'] == 'overview':
             raise serializers.ValidationError(
-                "Either Focus or Sub-lens is required for lens '{}'."
+                "Either Focus or Sub-lens is required for lens '{}'." +
                 " Valid sub-lens are: {}"
                 .format(data['lens'],
-                        self.DATA_SUB_LENS_MAP[data['lens']])
+                        DATA_SUB_LENS_MAP[data['lens']])
             )
 
         if 'sub_lens' in data and not data['lens'] == 'overview':
-            if not data['sub_lens'] in self.DATA_SUB_LENS_MAP[data['lens']]:
+            if not data['sub_lens'] in DATA_SUB_LENS_MAP[data['lens']]:
                 raise serializers.ValidationError(
                     "'{}' is not a valid sub-lens for '{}'."
                     " Valid sub-lens are: {}"
                     .format(data['sub_lens'], data['lens'],
-                            self.DATA_SUB_LENS_MAP[data['lens']])
+                            DATA_SUB_LENS_MAP[data['lens']])
                 )
 
         return data

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -1,4 +1,4 @@
-from complaint_search.defaults import PARAMS, DATA_SUB_LENS_MAP
+from complaint_search.defaults import DATA_SUB_LENS_MAP, PARAMS
 from localflavor.us.us_states import STATE_CHOICES
 from rest_framework import serializers
 
@@ -204,7 +204,7 @@ class TrendsInputSerializer(SearchInputSerializer):
            and 'sub_lens' not in data \
            and not data['lens'] == 'overview':
             raise serializers.ValidationError(
-                "Either Focus or Sub-lens is required for lens '{}'." +
+                "Either Focus or Sub-lens is required for lens '{}'."
                 " Valid sub-lens are: {}"
                 .format(data['lens'],
                         DATA_SUB_LENS_MAP[data['lens']])

--- a/complaint_search/tests/expected_results/trends_issue_focus__valid.json
+++ b/complaint_search/tests/expected_results/trends_issue_focus__valid.json
@@ -1,0 +1,636 @@
+{
+    "took": 362,
+    "timed_out": false,
+    "_shards": {
+        "total": 5,
+        "successful": 5,
+        "failed": 0
+    },
+    "hits": {
+        "total": 1609587,
+        "max_score": 0.0,
+        "hits": []
+    },
+    "aggregations": {
+        "dateRangeBrush": {
+            "doc_count": 256833,
+            "dateRangeBrush": {
+                "buckets": [
+                    {
+                        "key_as_string": "2017-01-01T00:00:00.000Z",
+                        "key": 1483228800000,
+                        "doc_count": 37975
+                    },
+                    {
+                        "key_as_string": "2018-01-01T00:00:00.000Z",
+                        "key": 1514764800000,
+                        "doc_count": 70244
+                    },
+                    {
+                        "key_as_string": "2019-01-01T00:00:00.000Z",
+                        "key": 1546300800000,
+                        "doc_count": 90950
+                    },
+                    {
+                        "key_as_string": "2020-01-01T00:00:00.000Z",
+                        "key": 1577836800000,
+                        "doc_count": 57664
+                    }
+                ]
+            }
+        },
+        "product": {
+            "doc_count": 256833,
+            "product": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 881,
+                "buckets": [
+                    {
+                        "key": "Credit reporting, credit repair services, or other personal consumer reports",
+                        "doc_count": 248864,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 56558,
+                                    "interval_diff": {
+                                        "value": -32034.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 88592,
+                                    "interval_diff": {
+                                        "value": 21191.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 67401,
+                                    "interval_diff": {
+                                        "value": 31088.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 36313
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Credit card or prepaid card",
+                        "doc_count": 2689,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 419,
+                                    "interval_diff": {
+                                        "value": -407.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 826,
+                                    "interval_diff": {
+                                        "value": -91.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 917,
+                                    "interval_diff": {
+                                        "value": 390.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 527
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Vehicle loan or lease",
+                        "doc_count": 1620,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 236,
+                                    "interval_diff": {
+                                        "value": -257.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 493,
+                                    "interval_diff": {
+                                        "value": -104.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 597,
+                                    "interval_diff": {
+                                        "value": 303.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 294
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Mortgage",
+                        "doc_count": 1492,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 206,
+                                    "interval_diff": {
+                                        "value": -213.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 419,
+                                    "interval_diff": {
+                                        "value": -103.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 522,
+                                    "interval_diff": {
+                                        "value": 177.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 345
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Student loan",
+                        "doc_count": 1287,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 134,
+                                    "interval_diff": {
+                                        "value": -202.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 336,
+                                    "interval_diff": {
+                                        "value": -155.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 491,
+                                    "interval_diff": {
+                                        "value": 165.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 326
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "max_date": {
+            "value": 1590512400000.0,
+            "value_as_string": "2020-05-26T12:00:00-05:00"
+        },
+        "issue": {
+            "doc_count": 256833,
+            "issue": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [
+                    {
+                        "key": "Incorrect information on your report",
+                        "doc_count": 256833,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 57664,
+                                    "interval_diff": {
+                                        "value": -33286.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 90950,
+                                    "interval_diff": {
+                                        "value": 20706.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 70244,
+                                    "interval_diff": {
+                                        "value": 32269.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 37975
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "min_date": {
+            "value": 1322758800000.0,
+            "value_as_string": "2011-12-01T12:00:00-05:00"
+        },
+        "dateRangeArea": {
+            "doc_count": 256833,
+            "dateRangeArea": {
+                "buckets": [
+                    {
+                        "key_as_string": "2017-01-01T00:00:00.000Z",
+                        "key": 1483228800000,
+                        "doc_count": 37975
+                    },
+                    {
+                        "key_as_string": "2018-01-01T00:00:00.000Z",
+                        "key": 1514764800000,
+                        "doc_count": 70244
+                    },
+                    {
+                        "key_as_string": "2019-01-01T00:00:00.000Z",
+                        "key": 1546300800000,
+                        "doc_count": 90950
+                    },
+                    {
+                        "key_as_string": "2020-01-01T00:00:00.000Z",
+                        "key": 1577836800000,
+                        "doc_count": 57664
+                    }
+                ]
+            }
+        },
+        "sub-issue": {
+            "doc_count": 256833,
+            "sub-issue": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 14781,
+                "buckets": [
+                    {
+                        "key": "Information belongs to someone else",
+                        "doc_count": 142692,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 41930,
+                                    "interval_diff": {
+                                        "value": -14751.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 56681,
+                                    "interval_diff": {
+                                        "value": 25205.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 31476,
+                                    "interval_diff": {
+                                        "value": 18871.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 12605
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Account status incorrect",
+                        "doc_count": 39929,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 5267,
+                                    "interval_diff": {
+                                        "value": -6066.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 11333,
+                                    "interval_diff": {
+                                        "value": -3107.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 14440,
+                                    "interval_diff": {
+                                        "value": 5551.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 8889
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Account information incorrect",
+                        "doc_count": 36563,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 5255,
+                                    "interval_diff": {
+                                        "value": -6069.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 11324,
+                                    "interval_diff": {
+                                        "value": -1148.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 12472,
+                                    "interval_diff": {
+                                        "value": 4960.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 7512
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Personal information incorrect",
+                        "doc_count": 11948,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 2129,
+                                    "interval_diff": {
+                                        "value": -2147.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 4276,
+                                    "interval_diff": {
+                                        "value": 833.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 3443,
+                                    "interval_diff": {
+                                        "value": 1343.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 2100
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Old information reappears or never goes away",
+                        "doc_count": 9426,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 1123,
+                                    "interval_diff": {
+                                        "value": -1342.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 2465,
+                                    "interval_diff": {
+                                        "value": -731.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 3196,
+                                    "interval_diff": {
+                                        "value": 554.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 2642
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "tags": {
+            "doc_count": 256833,
+            "tags": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [
+                    {
+                        "key": "Servicemember",
+                        "doc_count": 18870,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 2747,
+                                    "interval_diff": {
+                                        "value": -3227.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 5974,
+                                    "interval_diff": {
+                                        "value": -255.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 6229,
+                                    "interval_diff": {
+                                        "value": 2309.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 3920
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Older American",
+                        "doc_count": 3819,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 640,
+                                    "interval_diff": {
+                                        "value": -926.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 1566,
+                                    "interval_diff": {
+                                        "value": 646.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 920,
+                                    "interval_diff": {
+                                        "value": 227.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 693
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Older American, Servicemember",
+                        "doc_count": 1265,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 183,
+                                    "interval_diff": {
+                                        "value": -297.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 480,
+                                    "interval_diff": {
+                                        "value": 138.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 342,
+                                    "interval_diff": {
+                                        "value": 82.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 260
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "_meta": {
+        "date_min": "2011-12-01T12:00:00-05:00",
+        "date_max": "2020-05-26T12:00:00-05:00"
+    }
+}

--- a/complaint_search/tests/expected_results/trends_issue_focus_company_filter__valid.json
+++ b/complaint_search/tests/expected_results/trends_issue_focus_company_filter__valid.json
@@ -1,0 +1,650 @@
+{
+    "took": 321,
+    "timed_out": false,
+    "_shards": {
+        "total": 5,
+        "successful": 5,
+        "failed": 0
+    },
+    "hits": {
+        "total": 1609587,
+        "max_score": 0.0,
+        "hits": []
+    },
+    "aggregations": {
+        "dateRangeBrush": {
+            "doc_count": 69251,
+            "dateRangeBrush": {
+                "buckets": [
+                    {
+                        "key_as_string": "2017-01-01T00:00:00.000Z",
+                        "key": 1483228800000,
+                        "doc_count": 9914
+                    },
+                    {
+                        "key_as_string": "2018-01-01T00:00:00.000Z",
+                        "key": 1514764800000,
+                        "doc_count": 17976
+                    },
+                    {
+                        "key_as_string": "2019-01-01T00:00:00.000Z",
+                        "key": 1546300800000,
+                        "doc_count": 25648
+                    },
+                    {
+                        "key_as_string": "2020-01-01T00:00:00.000Z",
+                        "key": 1577836800000,
+                        "doc_count": 15713
+                    }
+                ]
+            }
+        },
+        "product": {
+            "doc_count": 69251,
+            "product": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 4,
+                "buckets": [
+                    {
+                        "key": "Credit reporting, credit repair services, or other personal consumer reports",
+                        "doc_count": 69217,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 15712,
+                                    "interval_diff": {
+                                        "value": -9930.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 25642,
+                                    "interval_diff": {
+                                        "value": 7676.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 17966,
+                                    "interval_diff": {
+                                        "value": 8069.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 9897
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Vehicle loan or lease",
+                        "doc_count": 11,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 1,
+                                    "interval_diff": {
+                                        "value": -5.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 6,
+                                    "interval_diff": {
+                                        "value": 2.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 4
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Student loan",
+                        "doc_count": 8,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 3,
+                                    "interval_diff": {
+                                        "value": 3.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 0,
+                                    "interval_diff": {
+                                        "value": -5.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 5
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Mortgage",
+                        "doc_count": 6,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 1,
+                                    "interval_diff": {
+                                        "value": -1.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 2,
+                                    "interval_diff": {
+                                        "value": -1.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 3
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Credit card or prepaid card",
+                        "doc_count": 5,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 1,
+                                    "interval_diff": {
+                                        "value": 0.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 1,
+                                    "interval_diff": {
+                                        "value": -2.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 3
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "max_date": {
+            "value": 1590512400000.0,
+            "value_as_string": "2020-05-26T12:00:00-05:00"
+        },
+        "issue": {
+            "doc_count": 69251,
+            "issue": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [
+                    {
+                        "key": "Incorrect information on your report",
+                        "doc_count": 69251,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 15713,
+                                    "interval_diff": {
+                                        "value": -9935.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 25648,
+                                    "interval_diff": {
+                                        "value": 7672.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 17976,
+                                    "interval_diff": {
+                                        "value": 8062.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 9914
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "min_date": {
+            "value": 1322758800000.0,
+            "value_as_string": "2011-12-01T12:00:00-05:00"
+        },
+        "dateRangeArea": {
+            "doc_count": 69251,
+            "dateRangeArea": {
+                "buckets": [
+                    {
+                        "key_as_string": "2017-01-01T00:00:00.000Z",
+                        "key": 1483228800000,
+                        "doc_count": 9914
+                    },
+                    {
+                        "key_as_string": "2018-01-01T00:00:00.000Z",
+                        "key": 1514764800000,
+                        "doc_count": 17976
+                    },
+                    {
+                        "key_as_string": "2019-01-01T00:00:00.000Z",
+                        "key": 1546300800000,
+                        "doc_count": 25648
+                    },
+                    {
+                        "key_as_string": "2020-01-01T00:00:00.000Z",
+                        "key": 1577836800000,
+                        "doc_count": 15713
+                    }
+                ]
+            }
+        },
+        "company": {
+            "doc_count": 69251,
+            "company": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [
+                    {
+                        "key": "EQUIFAX, INC.",
+                        "doc_count": 69251,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 9914
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 17976,
+                                    "interval_diff": {
+                                        "value": 8062.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 25648,
+                                    "interval_diff": {
+                                        "value": 7672.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 15713,
+                                    "interval_diff": {
+                                        "value": -9935.0
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "sub-issue": {
+            "doc_count": 69251,
+            "sub-issue": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 3532,
+                "buckets": [
+                    {
+                        "key": "Information belongs to someone else",
+                        "doc_count": 43112,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 12212,
+                                    "interval_diff": {
+                                        "value": -5836.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 18048,
+                                    "interval_diff": {
+                                        "value": 8795.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 9253,
+                                    "interval_diff": {
+                                        "value": 5654.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 3599
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Account status incorrect",
+                        "doc_count": 8419,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 1066,
+                                    "interval_diff": {
+                                        "value": -1171.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 2237,
+                                    "interval_diff": {
+                                        "value": -869.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 3106,
+                                    "interval_diff": {
+                                        "value": 1096.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 2010
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Account information incorrect",
+                        "doc_count": 8155,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 1157,
+                                    "interval_diff": {
+                                        "value": -1322.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 2479,
+                                    "interval_diff": {
+                                        "value": -256.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 2735,
+                                    "interval_diff": {
+                                        "value": 951.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 1784
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Personal information incorrect",
+                        "doc_count": 3535,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 590,
+                                    "interval_diff": {
+                                        "value": -641.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 1231,
+                                    "interval_diff": {
+                                        "value": 203.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 1028,
+                                    "interval_diff": {
+                                        "value": 342.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 686
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Public record information inaccurate",
+                        "doc_count": 2492,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 259,
+                                    "interval_diff": {
+                                        "value": -409.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 668,
+                                    "interval_diff": {
+                                        "value": -68.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 736,
+                                    "interval_diff": {
+                                        "value": -93.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 829
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "tags": {
+            "doc_count": 69251,
+            "tags": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [
+                    {
+                        "key": "Servicemember",
+                        "doc_count": 4626,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 658,
+                                    "interval_diff": {
+                                        "value": -786.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 1444,
+                                    "interval_diff": {
+                                        "value": -51.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 1495,
+                                    "interval_diff": {
+                                        "value": 466.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 1029
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Older American",
+                        "doc_count": 901,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 148,
+                                    "interval_diff": {
+                                        "value": -212.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 360,
+                                    "interval_diff": {
+                                        "value": 152.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 208,
+                                    "interval_diff": {
+                                        "value": 23.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 185
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Older American, Servicemember",
+                        "doc_count": 283,
+                        "trend_period": {
+                            "buckets": [
+                                {
+                                    "key_as_string": "2020-01-01T00:00:00.000Z",
+                                    "key": 1577836800000,
+                                    "doc_count": 34,
+                                    "interval_diff": {
+                                        "value": -67.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2019-01-01T00:00:00.000Z",
+                                    "key": 1546300800000,
+                                    "doc_count": 101,
+                                    "interval_diff": {
+                                        "value": 26.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2018-01-01T00:00:00.000Z",
+                                    "key": 1514764800000,
+                                    "doc_count": 75,
+                                    "interval_diff": {
+                                        "value": 2.0
+                                    }
+                                },
+                                {
+                                    "key_as_string": "2017-01-01T00:00:00.000Z",
+                                    "key": 1483228800000,
+                                    "doc_count": 73
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "_meta": {
+        "date_min": "2011-12-01T12:00:00-05:00",
+        "date_max": "2020-05-26T12:00:00-05:00"
+    }
+}

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -45,6 +45,7 @@ QPARAMS_VARS = (
     'date_received_max',
     'date_received_min',
     'field',
+    'focus',
     'frm',
     'lens',
     'no_aggs',


### PR DESCRIPTION
Rather than providing a sub lens through which to view the trends aggregations, this PR adds the Focus functionality which facilitates lens filtering by a single provided item (eg, a particular product or issue).

 Features:
* `/trends/` endpoint now accepts `focus` as a param
* Aggregations are filtered based on the focus provided

Fixes:
* Fixed an issue where the `company` filter was being incorrectly applied to `/states/`