### PR TITLE
Don't apply state filter to /states/ aggregation

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -488,7 +488,7 @@ class StateAggregationBuilder(BaseBuilder):
         for item in self.params:
             if item in (
                 self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ) and not item == 'state':
+            ) and not (field_name == 'state' and item == 'state'):
                 field_level_should = {
                     "bool": {"should": self.filter_clauses[item]}
                 }

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -488,7 +488,7 @@ class StateAggregationBuilder(BaseBuilder):
         for item in self.params:
             if item in (
                 self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ):
+            ) and not item == 'state':
                 field_level_should = {
                     "bool": {"should": self.filter_clauses[item]}
                 }


### PR DESCRIPTION
In order to provide the most detailed complaint counts on the map screen, the `/states/` endpoint should return the states aggregation without applying the states filters to it. This prevents all other states from being zeroed out when a state filter is selected.