### PR TITLE
Not filters

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -36,6 +36,8 @@ SOURCE_FIELDS = (
     "zip_code",
 )
 
+EXCLUDE_PREFIX = 'not_'
+
 EXPORT_FORMATS = (
     'csv',
     'json',

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -1,11 +1,12 @@
 import abc
 import copy
 import re
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 
 from complaint_search.defaults import (
     DATA_SUB_LENS_MAP,
     DELIMITER,
+    EXCLUDE_PREFIX,
     EXPORT_FORMATS,
     PARAMS,
     SOURCE_FIELDS,
@@ -94,89 +95,220 @@ class BaseBuilder(object):
     def add(self, **kwargs):
         self.params.update(**kwargs)
 
-    @abc.abstractmethod
-    def build(self):
-        """Method that will build the body dictionary."""
+    # This creates all the bool should filter clauses for a field
+    def _build_bool_clauses(self, field, value_list):
+        assert value_list
 
-    # This create all the bool should filter clauses for a field
-    # es_field_name: a field name (to be filtered in ES)
-    # value_list: a list of values to be filtered for this field
-    # with_child: set to true if this field has a child field
-    # es_child_field_name: if with_child is true, this holds the field
-    # name of the child used (to be filtered in ES)
-    def _build_bool_clauses(self, field):
         es_field_name = self._get_es_name(field)
-        value_list = (
-            [
-                0 if cd.lower() == "no" else 1 for cd in self.params[field]
-            ]
-            if field in self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            else self.params.get(field)
-        )
 
-        if value_list:
-            # The most common property for data is to not have a child element
-            if not self._has_child(field):
-                term_list_container = {"terms": {es_field_name: []}}
+        # The most common property for data is to not have a child element
+        if not self._has_child(field):
+            return {
+                "terms": {
+                    es_field_name: value_list
+                }}
 
-                term_list_container["terms"][es_field_name] = value_list
+        else:
+            item_dict = defaultdict(list)
+            for v in value_list:
+                v_pair = v.split(DELIMITER)
+                # No child specified
+                if len(v_pair) == 1:
+                    # This will initialize empty list for item if not in
+                    # item_dict yet
+                    item_dict[v_pair[0]]
+                elif len(v_pair) == 2:
+                    # put subproduct into list
+                    item_dict[v_pair[0]].append(v_pair[1])
 
-                return term_list_container
-            else:
-                item_dict = OrderedDict()
-                for v in value_list:
-                    v_pair = v.split(DELIMITER)
-                    item_dict.setdefault(v_pair[0], [])
-                    if len(v_pair) == 2:
-                        # put subproduct into list
-                        item_dict[v_pair[0]].append(v_pair[1])
+            # Go through item_dict to create filters
+            f_list = []
+            for item, child in item_dict.items():
+                # Always append the item to list
+                parent_term = {"term": {es_field_name: item}}
+                if not child:
+                    f_list.append(parent_term)
+                else:
+                    child_field = self._get_es_name(self._get_child(field))
+                    child_term = {
+                        "terms": {
+                            child_field: child
+                        }
+                    }
+                    parent_child_bool_structure = {
+                        "bool": {
+                            "must": [
+                                parent_term,
+                                child_term
+                            ],
+                        }
+                    }
 
-                # Go through item_dict to create filters
-                f_list = []
-                for item, child in item_dict.items():
-                    # Always append the item to list
-                    parent_term = {"terms": {es_field_name: [item]}}
-                    if not child:
-                        f_list.append(parent_term)
-                    else:
-                        child_term = {"terms": {
-                            self._get_es_name(self._get_child(field)): child
-                        }}
-                        parent_child_bool_structure = {"bool": {
-                            "must": [], "should": []
-                        }}
-                        parent_child_bool_structure["bool"]["must"].append(
-                            parent_term)
-                        parent_child_bool_structure["bool"]["should"].append(
-                            child_term)
+                    f_list.append(parent_child_bool_structure)
 
-                        f_list.append(parent_child_bool_structure)
+            return f_list
 
-                return f_list
+    # This creates two dictionaries where the keys are the field name
+    # dictionary 1: the conditions for including a record in the query
+    # dictionary 2: the conditions for excluding a record in the query
 
-    # This creates a dictionary of all filter_clauses, where the keys are the
-    # field name
-    def _build_filter_clauses(self):
-        filter_clauses = {}
-        for item in self.params:
-            if item in (self._OPTIONAL_FILTERS +
-                        self._OPTIONAL_FILTERS_STRING_TO_BOOL):
-                filter_clauses[item] = self._build_bool_clauses(item)
-        return filter_clauses
+    def _build_clauses_dictionary(self):
+        include_clauses = OrderedDict()
+        exclude_clauses = OrderedDict()
+        for item in self._OPTIONAL_FILTERS:
+            values = self.params.get(item)
+            if values:
+                include_clauses[item] = self._build_bool_clauses(item, values)
+
+            # handle the not item case
+            values = self.params.get(EXCLUDE_PREFIX + item)
+            if values:
+                exclude_clauses[item] = self._build_bool_clauses(item, values)
+
+        return include_clauses, exclude_clauses
 
     def _build_date_range_filter(self, date_min, date_max, es_field_name):
+        # 2019-10-17 JMF - Tests fails when using "from builtins import str"
+        # The result gets flagged as "bad type" since type = future.types. ...
+        try:
+            _fn = unicode  # PY2
+        except NameError:
+            _fn = str  # PY3
+
         date_clause = {}
-        timeSuffix = u'T12:00:00-05:00'
         if date_min or date_max:
             date_clause = {"range": {es_field_name: {}}}
             if date_min:
-                d = str(date_min) + timeSuffix
-                date_clause["range"][es_field_name]["from"] = d
+                date_clause["range"][es_field_name]["from"] = _fn(date_min)
             if date_max:
-                d = str(date_max) + timeSuffix
-                date_clause["range"][es_field_name]["to"] = d
+                date_clause["range"][es_field_name]["to"] = _fn(date_max)
 
         return date_clause
+
+    def _build_dsl_filter(self, include_clauses, exclude_clauses,
+                          include_dates=True, single_not_clause=True):
+        andClauses = []
+
+        # date_received
+        date_received = self._build_date_range_filter(
+            self.params.get("date_received_min"),
+            self.params.get("date_received_max"),
+            "created_time")
+
+        if date_received and include_dates:
+            andClauses.append(date_received)
+
+        # Create filter clauses for all other filters
+        for item, clauses in include_clauses.items():
+            if not self._has_child(item):
+                # Create the field level AND query that must match
+                andClauses.append(clauses)
+            else:
+                # These get added as compound OR clauses
+                orClause = {"bool": {"should": clauses}}
+                andClauses.append(orClause)
+
+        notClauses = []
+        for item, clauses in exclude_clauses.items():
+            if not self._has_child(item):
+                # Create the field level AND query that must match
+                notClauses.append(clauses)
+            else:
+                # These get added as compound OR clauses
+                orClause = {"bool": {"should": clauses}}
+                notClauses.append(orClause)
+
+        # if there are multiple not clauses, they need to be grouped
+        # ~A AND ~B AND ~C is not the same as ~(A AND B AND C)
+        if len(notClauses) > 1 and single_not_clause:
+            grouping = {"bool": {"must": notClauses}}
+            notClauses = [grouping]
+
+        return {"bool": {"must": andClauses, "must_not": notClauses}}
+
+    # @abc.abstractmethod
+    # def build(self):
+    #     """Method that will build the body dictionary."""
+
+    # # This create all the bool should filter clauses for a field
+    # # es_field_name: a field name (to be filtered in ES)
+    # # value_list: a list of values to be filtered for this field
+    # # with_child: set to true if this field has a child field
+    # # es_child_field_name: if with_child is true, this holds the field
+    # # name of the child used (to be filtered in ES)
+    # def _build_bool_clauses(self, field):
+    #     es_field_name = self._get_es_name(field)
+    #     value_list = (
+    #         [
+    #             0 if cd.lower() == "no" else 1 for cd in self.params[field]
+    #         ]
+    #         if field in self._OPTIONAL_FILTERS_STRING_TO_BOOL
+    #         else self.params.get(field)
+    #     )
+
+    #     if value_list:
+    #         # The most common property for data is to not have a child element
+    #         if not self._has_child(field):
+    #             term_list_container = {"terms": {es_field_name: []}}
+
+    #             term_list_container["terms"][es_field_name] = value_list
+
+    #             return term_list_container
+    #         else:
+    #             item_dict = OrderedDict()
+    #             for v in value_list:
+    #                 v_pair = v.split(DELIMITER)
+    #                 item_dict.setdefault(v_pair[0], [])
+    #                 if len(v_pair) == 2:
+    #                     # put subproduct into list
+    #                     item_dict[v_pair[0]].append(v_pair[1])
+
+    #             # Go through item_dict to create filters
+    #             f_list = []
+    #             for item, child in item_dict.items():
+    #                 # Always append the item to list
+    #                 parent_term = {"terms": {es_field_name: [item]}}
+    #                 if not child:
+    #                     f_list.append(parent_term)
+    #                 else:
+    #                     child_term = {"terms": {
+    #                         self._get_es_name(self._get_child(field)): child
+    #                     }}
+    #                     parent_child_bool_structure = {"bool": {
+    #                         "must": [], "should": []
+    #                     }}
+    #                     parent_child_bool_structure["bool"]["must"].append(
+    #                         parent_term)
+    #                     parent_child_bool_structure["bool"]["should"].append(
+    #                         child_term)
+
+    #                     f_list.append(parent_child_bool_structure)
+
+    #             return f_list
+
+    # # This creates a dictionary of all filter_clauses, where the keys are the
+    # # field name
+    # def _build_filter_clauses(self):
+    #     filter_clauses = {}
+    #     for item in self.params:
+    #         if item in (self._OPTIONAL_FILTERS +
+    #                     self._OPTIONAL_FILTERS_STRING_TO_BOOL):
+    #             filter_clauses[item] = self._build_bool_clauses(item)
+    #     return filter_clauses
+
+    # def _build_date_range_filter(self, date_min, date_max, es_field_name):
+    #     date_clause = {}
+    #     timeSuffix = u'T12:00:00-05:00'
+    #     if date_min or date_max:
+    #         date_clause = {"range": {es_field_name: {}}}
+    #         if date_min:
+    #             d = str(date_min) + timeSuffix
+    #             date_clause["range"][es_field_name]["from"] = d
+    #         if date_max:
+    #             d = str(date_max) + timeSuffix
+    #             date_clause["range"][es_field_name]["to"] = d
+
+    #     return date_clause
 
 
 class SearchBuilder(BaseBuilder):
@@ -253,41 +385,44 @@ class SearchBuilder(BaseBuilder):
 
 class PostFilterBuilder(BaseBuilder):
 
+    # def build(self):
+    #     filter_clauses = self._build_filter_clauses()
+
+    #     post_filter = {"bool": {"should": [], "must": [], "filter": []}}
+
+    #     # date_received
+    #     date_received = self._build_date_range_filter(
+    #         self.params.get("date_received_min"),
+    #         self.params.get("date_received_max"),
+    #         "date_received")
+
+    #     if date_received:
+    #         post_filter["bool"]["filter"].append(date_received)
+
+    #     # company_received
+    #     company_received = self._build_date_range_filter(
+    #         self.params.get("company_received_min"),
+    #         self.params.get("company_received_max"),
+    #         "date_sent_to_company")
+
+    #     if company_received:
+    #         post_filter["bool"]["filter"].append(company_received)
+
+    #     # Create filter clauses for all other filters
+    #     for item in self.params:
+    #         if item in (
+    #             self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+    #         ):
+    #             # for filters selected, we are creating the field level OR
+    #             # query that must match e.g (this OR that) AND (y or z) AND
+    #             # servicemember
+    #             field_level_should = {"bool": {"should": filter_clauses[item]}}
+    #             post_filter["bool"]["filter"].append(field_level_should)
+
+    #     return post_filter
     def build(self):
-        filter_clauses = self._build_filter_clauses()
-
-        post_filter = {"bool": {"should": [], "must": [], "filter": []}}
-
-        # date_received
-        date_received = self._build_date_range_filter(
-            self.params.get("date_received_min"),
-            self.params.get("date_received_max"),
-            "date_received")
-
-        if date_received:
-            post_filter["bool"]["filter"].append(date_received)
-
-        # company_received
-        company_received = self._build_date_range_filter(
-            self.params.get("company_received_min"),
-            self.params.get("company_received_max"),
-            "date_sent_to_company")
-
-        if company_received:
-            post_filter["bool"]["filter"].append(company_received)
-
-        # Create filter clauses for all other filters
-        for item in self.params:
-            if item in (
-                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ):
-                # for filters selected, we are creating the field level OR
-                # query that must match e.g (this OR that) AND (y or z) AND
-                # servicemember
-                field_level_should = {"bool": {"should": filter_clauses[item]}}
-                post_filter["bool"]["filter"].append(field_level_should)
-
-        return post_filter
+        include_clauses, exclude_clauses = self._build_clauses_dictionary()
+        return self._build_dsl_filter(include_clauses, exclude_clauses)
 
 
 class AggregationBuilder(BaseBuilder):
@@ -307,95 +442,205 @@ class AggregationBuilder(BaseBuilder):
         'zip_code'
     )
 
+    # def __init__(self):
+    #     BaseBuilder.__init__(self)
+    #     self.include_clauses = None
+    #     self.exclude_clauses = None
+    #     self.exclude = []
+
+    # def add_exclude(self, field_name_list):
+    #     self.exclude += field_name_list
+
+    # def build_one(self, field_name):
+    #     # Lazy initialization
+    #     if not self.filter_clauses:
+    #         self.filter_clauses = self._build_filter_clauses()
+
+    #     field_aggs = {
+    #         "filter": {
+    #             "bool": {
+    #                 "must": [],
+    #                 "should": [],
+    #                 "filter": [],
+    #             }
+    #         }
+    #     }
+
+    #     es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
+    #         field_name, field_name
+    #     )
+    #     es_child_name = None
+    #     if field_name in self._OPTIONAL_FILTERS_CHILD_MAP:
+    #         es_child_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
+    #             self._OPTIONAL_FILTERS_CHILD_MAP.get(field_name))
+    #         field_aggs["aggs"] = {
+    #             field_name: {
+    #                 "terms": {
+    #                     "field": es_field_name,
+    #                     "size": 0
+    #                 },
+    #                 "aggs": {
+    #                     es_child_name: {
+    #                         "terms": {
+    #                             "field": es_child_name,
+    #                             "size": 0
+    #                         }
+    #                     }
+    #                 }
+    #             }
+    #         }
+    #     else:
+    #         field_aggs["aggs"] = {
+    #             field_name: {
+    #                 "terms": {
+    #                     "field": es_field_name,
+    #                     "size": 0
+    #                 }
+    #             }
+    #         }
+
+    #     date_filter = self._build_date_range_filter(
+    #         self.params.get("date_received_min"),
+    #         self.params.get("date_received_max"), "date_received")
+
+    #     if date_filter:
+    #         field_aggs["filter"]["bool"]["filter"].append(date_filter)
+
+    #     company_filter = self._build_date_range_filter(
+    #         self.params.get("company_received_min"),
+    #         self.params.get("company_received_max"), "date_sent_to_company")
+
+    #     if company_filter:
+    #         field_aggs["filter"]["bool"]["filter"].append(company_filter)
+
+    #     # Add filter clauses to aggregation entries (only those that are not
+    #     # the same as field name or part of the exclude list, which means we
+    #     # want to list all matched aggregation)
+    #     for item in self.params:
+    #         include_filter = (
+    #             item != field_name or
+    #             (item == field_name and item in self.exclude)
+    #         )
+
+    #         if include_filter and item in (
+    #             self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+    #         ):
+    #             field_level_should = {
+    #                 "bool": {"should": self.filter_clauses[item]}
+    #             }
+    #             field_aggs["filter"]["bool"]["filter"].append(
+    #                 field_level_should
+    #             )
+
+    #     return field_aggs
+
+    # def build(self):
+    #     aggs = {}
+
+    #     agg_fields = self._AGG_FIELDS
+    #     if self.exclude:
+    #         agg_fields = [field_name for field_name in self._AGG_FIELDS
+    #                       if field_name not in self.exclude
+    #                       or field_name in self.params]
+    #     for field_name in agg_fields:
+    #         aggs[field_name] = self.build_one(field_name)
+
+    #     return aggs
+
+    _AGG_HEADING_MAP = {
+        'collection': "Collections",
+        'company': "Matched Company",
+        'company_response': "Company Response",
+        'consumer_disputed': "Consumer Disputed?",
+        'consent_status': "Consumer consent provided?",
+        'issue': "Issue",
+        'older_american': "Older American",
+        'product': "Product",
+        "referred_by": "Referred By",
+        "referred_to": "Referred To",
+        'service_member': "Servicemember",
+        'status': "Status",
+    }
+
     def __init__(self):
         BaseBuilder.__init__(self)
-        self.filter_clauses = None
+        self.include_clauses = None
+        self.exclude_clauses = None
         self.exclude = []
 
     def add_exclude(self, field_name_list):
         self.exclude += field_name_list
 
-    def build_one(self, field_name):
-        # Lazy initialization
-        if not self.filter_clauses:
-            self.filter_clauses = self._build_filter_clauses()
-
-        field_aggs = {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [],
-                }
-            }
-        }
-
-        es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
-            field_name, field_name
-        )
-        es_child_name = None
-        if field_name in self._OPTIONAL_FILTERS_CHILD_MAP:
-            es_child_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
-                self._OPTIONAL_FILTERS_CHILD_MAP.get(field_name))
-            field_aggs["aggs"] = {
-                field_name: {
-                    "terms": {
-                        "field": es_field_name,
-                        "size": 0
-                    },
-                    "aggs": {
-                        es_child_name: {
-                            "terms": {
-                                "field": es_child_name,
-                                "size": 0
-                            }
+    def build_parent_child_field_agg(
+        self, agg_heading_name, es_parent_name, es_child_name
+    ):
+        return {
+            agg_heading_name: {
+                "terms": {
+                    "field": es_parent_name,
+                    "size": 0
+                },
+                "aggs": {
+                    es_child_name: {
+                        "terms": {
+                            "field": es_child_name,
+                            "size": 0
                         }
                     }
                 }
             }
-        else:
+        }
+
+    def build_one(self, field_name):
+        # Lazy initialization
+        if not self.include_clauses:
+            self.include_clauses, self.exclude_clauses = \
+                self._build_clauses_dictionary()
+
+        field_aggs = {}
+        census_year = self.params.get("census_year")
+
+        es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
+            field_name, field_name
+        )
+        agg_heading_name = self.header_name(field_name)
+        es_child_name = None
+
+        if field_name in self._OPTIONAL_FILTERS_CHILD_MAP:
+            es_child_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
+                self._OPTIONAL_FILTERS_CHILD_MAP.get(field_name))
+            field_aggs["aggs"] = self.build_parent_child_field_agg(
+                agg_heading_name,
+                es_field_name,
+                es_child_name
+            )
+
+        elif field_name == 'company':
             field_aggs["aggs"] = {
-                field_name: {
+                "Matched Company": {
                     "terms": {
-                        "field": es_field_name,
+                        "field": "company_name",
                         "size": 0
                     }
                 }
             }
 
-        date_filter = self._build_date_range_filter(
-            self.params.get("date_received_min"),
-            self.params.get("date_received_max"), "date_received")
-
-        if date_filter:
-            field_aggs["filter"]["bool"]["filter"].append(date_filter)
-
-        company_filter = self._build_date_range_filter(
-            self.params.get("company_received_min"),
-            self.params.get("company_received_max"), "date_sent_to_company")
-
-        if company_filter:
-            field_aggs["filter"]["bool"]["filter"].append(company_filter)
-
-        # Add filter clauses to aggregation entries (only those that are not
-        # the same as field name or part of the exclude list, which means we
-        # want to list all matched aggregation)
-        for item in self.params:
-            include_filter = (
-                item != field_name or
-                (item == field_name and item in self.exclude)
-            )
-
-            if include_filter and item in (
-                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ):
-                field_level_should = {
-                    "bool": {"should": self.filter_clauses[item]}
+        else:
+            # Note: if/when we move to a single shard for aggregations,
+            # we can use 'size: size' for variable-length aggregations
+            field_aggs["aggs"] = {
+                agg_heading_name: {
+                    "terms": {
+                        "field": es_field_name,
+                        # "size": size,
+                        "size": 0
+                    }
                 }
-                field_aggs["filter"]["bool"]["filter"].append(
-                    field_level_should
-                )
+            }
 
+        # Add the aggregation filters
+        field_aggs['filter'] = self._build_dsl_filter(self.include_clauses,
+                                                      self.exclude_clauses)
         return field_aggs
 
     def build(self):
@@ -403,13 +648,18 @@ class AggregationBuilder(BaseBuilder):
 
         agg_fields = self._AGG_FIELDS
         if self.exclude:
-            agg_fields = [field_name for field_name in self._AGG_FIELDS
-                          if field_name not in self.exclude
-                          or field_name in self.params]
+            agg_fields = [
+                field_name for field_name in self._AGG_FIELDS
+                if field_name not in self.exclude or field_name in self.params
+            ]
         for field_name in agg_fields:
-            aggs[field_name] = self.build_one(field_name)
+            aggs[self._AGG_HEADING_MAP.get(field_name, field_name)] = \
+                self.build_one(field_name)
 
         return aggs
+
+    def header_name(self, field_name):
+        return self._AGG_HEADING_MAP.get(field_name, field_name)
 
 
 class StateAggregationBuilder(BaseBuilder):
@@ -427,7 +677,8 @@ class StateAggregationBuilder(BaseBuilder):
 
     def __init__(self):
         BaseBuilder.__init__(self)
-        self.filter_clauses = None
+        self.include_clauses = None
+        self.exclude_clauses = None
         self.exclude = []
 
     def add_exclude(self, field_name_list):
@@ -435,8 +686,9 @@ class StateAggregationBuilder(BaseBuilder):
 
     def build_one(self, field_name):
         # Lazy initialization
-        if not self.filter_clauses:
-            self.filter_clauses = self._build_filter_clauses()
+        if not self.include_clauses:
+            self.include_clauses, self.exclude_clauses = \
+                self._build_clauses_dictionary()
 
         field_aggs = {
             "filter": {
@@ -477,30 +729,33 @@ class StateAggregationBuilder(BaseBuilder):
                 }
             }
 
-        date_filter = self._build_date_range_filter(
-            self.params.get("date_received_min"),
-            self.params.get("date_received_max"), "date_received")
+        # date_filter = self._build_date_range_filter(
+        #     self.params.get("date_received_min"),
+        #     self.params.get("date_received_max"), "date_received")
 
-        if date_filter:
-            field_aggs["filter"]["bool"]["filter"].append(date_filter)
+        # if date_filter:
+        #     field_aggs["filter"]["bool"]["filter"].append(date_filter)
 
-        company_filter = self._build_date_range_filter(
-            self.params.get("company_received_min"),
-            self.params.get("company_received_max"), "date_sent_to_company")
+        # company_filter = self._build_date_range_filter(
+        #     self.params.get("company_received_min"),
+        #     self.params.get("company_received_max"), "date_sent_to_company")
 
-        if company_filter:
-            field_aggs["filter"]["bool"]["filter"].append(company_filter)
+        # if company_filter:
+        #     field_aggs["filter"]["bool"]["filter"].append(company_filter)
 
-        for item in self.params:
-            if item in (
-                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ) and not (field_name == 'state' and item == 'state'):
-                field_level_should = {
-                    "bool": {"should": self.filter_clauses[item]}
-                }
-                field_aggs["filter"]["bool"]["filter"].append(
-                    field_level_should
-                )
+        # for item in self.params:
+        #     if item in (
+        #         self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+        #     ) and not (field_name == 'state' and item == 'state'):
+        #         field_level_should = {
+        #             "bool": {"should": self.filter_clauses[item]}
+        #         }
+        #         field_aggs["filter"]["bool"]["filter"].append(
+        #             field_level_should
+        #         )
+
+        field_aggs['filter'] = self._build_dsl_filter(self.include_clauses,
+                                                      self.exclude_clauses)
 
         return field_aggs
 
@@ -526,10 +781,22 @@ class LensAggregationBuilder(BaseBuilder):
         'tags': 'tags'
     }
 
+    # def __init__(self):
+    #     super(LensAggregationBuilder, self).__init__()
+    #     self.filter_clauses = None
+    #     self.exclude = []
     def __init__(self):
         super(LensAggregationBuilder, self).__init__()
-        self.filter_clauses = None
+        self._include_clauses = None
+        self.exclude_clauses = None
         self.exclude = []
+
+    @property
+    def include_clauses(self):
+        if not self._include_clauses:
+            self._include_clauses, self.exclude_clauses = \
+                self._build_clauses_dictionary()
+        return self._include_clauses
 
     def add_exclude(self, field_name_list):
         self.exclude += field_name_list
@@ -546,46 +813,54 @@ class LensAggregationBuilder(BaseBuilder):
             }
         }
 
-        # Lazy initialization
-        if not self.filter_clauses:
-            self.filter_clauses = self._build_filter_clauses()
+        # # Lazy initialization
+        # if not self.filter_clauses:
+        #     # self.filter_clauses = self._build_filter_clauses()
+        #     self.filter_clauses = self._build_dsl_filter()
 
-        filters = {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [],
-                }
-            }
-        }
+        # filters = {
+        #     "filter": {
+        #         "bool": {
+        #             "must": [],
+        #             "should": [],
+        #             "filter": [],
+        #         }
+        #     }
+        # }
 
-        date_filter = self._build_date_range_filter(
-            self.params.get("date_received_min"),
-            self.params.get("date_received_max"), "date_received")
+        # date_filter = self._build_date_range_filter(
+        #     self.params.get("date_received_min"),
+        #     self.params.get("date_received_max"), "date_received")
 
-        if date_filter and include_date_filter:
-            filters["filter"]["bool"]["filter"].append(date_filter)
+        # if date_filter and include_date_filter:
+        #     filters["filter"]["bool"]["filter"].append(date_filter)
 
-        company_filter = self._build_date_range_filter(
-            self.params.get("company_received_min"),
-            self.params.get("company_received_max"), "date_sent_to_company")
+        # company_filter = self._build_date_range_filter(
+        #     self.params.get("company_received_min"),
+        #     self.params.get("company_received_max"), "date_sent_to_company")
 
-        if company_filter:
-            filters["filter"]["bool"]["filter"].append(company_filter)
+        # if company_filter:
+        #     filters["filter"]["bool"]["filter"].append(company_filter)
 
-        for item in self.params:
-            if item in (
-                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ):
-                field_level_should = {
-                    "bool": {"should": self.filter_clauses[item]}
-                }
-                filters["filter"]["bool"]["filter"].append(
-                    field_level_should
-                )
+        # for item in self.params:
+        #     if item in (
+        #         self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+        #     ):
+        #         field_level_should = {
+        #             "bool": {"should": self.filter_clauses[item]}
+        #         }
+        #         filters["filter"]["bool"]["filter"].append(
+        #             field_level_should
+        #         )
 
-        agg['filter'] = filters['filter']
+        # agg['filter'] = filters['filter']
+
+        # Add filter clauses
+        agg['filter'] = self._build_dsl_filter(
+            self.include_clauses, self.exclude_clauses,
+            include_dates=include_date_filter,
+            single_not_clause=False
+        )
 
         return agg
 
@@ -652,46 +927,52 @@ class TrendsAggregationBuilder(LensAggregationBuilder):
         field_aggs["aggs"][agg_heading_name] = self.percent_change_agg(
             es_field_name, interval, self.params['trend_depth'])
 
-        # Lazy initialization
-        if not self.filter_clauses:
-            self.filter_clauses = self._build_filter_clauses()
+        # # Lazy initialization
+        # if not self.filter_clauses:
+        #     # self.filter_clauses = self._build_filter_clauses()
+        #     self.filter_clauses = self._build_dsl_filter()
 
-        filters = {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [],
-                }
-            }
-        }
+        # filters = {
+        #     "filter": {
+        #         "bool": {
+        #             "must": [],
+        #             "should": [],
+        #             "filter": [],
+        #         }
+        #     }
+        # }
 
-        date_filter = self._build_date_range_filter(
-            self.params.get("date_received_min"),
-            self.params.get("date_received_max"), "date_received")
+        # date_filter = self._build_date_range_filter(
+        #     self.params.get("date_received_min"),
+        #     self.params.get("date_received_max"), "date_received")
 
-        if date_filter:
-            filters["filter"]["bool"]["filter"].append(date_filter)
+        # if date_filter:
+        #     filters["filter"]["bool"]["filter"].append(date_filter)
 
-        company_filter = self._build_date_range_filter(
-            self.params.get("company_received_min"),
-            self.params.get("company_received_max"), "date_sent_to_company")
+        # company_filter = self._build_date_range_filter(
+        #     self.params.get("company_received_min"),
+        #     self.params.get("company_received_max"), "date_sent_to_company")
 
-        if company_filter:
-            filters["filter"]["bool"]["filter"].append(company_filter)
+        # if company_filter:
+        #     filters["filter"]["bool"]["filter"].append(company_filter)
 
-        for item in self.params:
-            if item in (
-                self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-            ):
-                field_level_should = {
-                    "bool": {"should": self.filter_clauses[item]}
-                }
-                filters["filter"]["bool"]["filter"].append(
-                    field_level_should
-                )
+        # for item in self.params:
+        #     if item in (
+        #         self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
+        #     ):
+        #         field_level_should = {
+        #             "bool": {"should": self.filter_clauses[item]}
+        #         }
+        #         filters["filter"]["bool"]["filter"].append(
+        #             field_level_should
+        #         )
 
-        field_aggs['filter'] = filters['filter']
+        # field_aggs['filter'] = filters['filter']
+
+        # Add the filters
+        field_aggs['filter'] = self._build_dsl_filter(
+            self.include_clauses, self.exclude_clauses, single_not_clause=False
+        )
 
         return field_aggs
 

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -1,7 +1,7 @@
 import abc
 import copy
 import re
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 
 from complaint_search.defaults import (
     DATA_SUB_LENS_MAP,
@@ -94,6 +94,10 @@ class BaseBuilder(object):
 
     def add(self, **kwargs):
         self.params.update(**kwargs)
+
+    @abc.abstractmethod
+    def build(self):
+        """Method that will build the body dictionary."""
 
     # This creates all the bool should filter clauses for a field
     def _build_bool_clauses(self, field, value_list):
@@ -198,6 +202,13 @@ class BaseBuilder(object):
         if date_received and include_dates:
             andClauses.append(date_received)
 
+        company_filter = self._build_date_range_filter(
+            self.params.get("company_received_min"),
+            self.params.get("company_received_max"), "date_sent_to_company")
+
+        if company_filter:
+            andClauses.append(company_filter)
+
         # Create filter clauses for all other filters
         for item, clauses in include_clauses.items():
             if not self._has_child(item):
@@ -225,90 +236,6 @@ class BaseBuilder(object):
             notClauses = [grouping]
 
         return {"bool": {"must": andClauses, "must_not": notClauses}}
-
-    # @abc.abstractmethod
-    # def build(self):
-    #     """Method that will build the body dictionary."""
-
-    # # This create all the bool should filter clauses for a field
-    # # es_field_name: a field name (to be filtered in ES)
-    # # value_list: a list of values to be filtered for this field
-    # # with_child: set to true if this field has a child field
-    # # es_child_field_name: if with_child is true, this holds the field
-    # # name of the child used (to be filtered in ES)
-    # def _build_bool_clauses(self, field):
-    #     es_field_name = self._get_es_name(field)
-    #     value_list = (
-    #         [
-    #             0 if cd.lower() == "no" else 1 for cd in self.params[field]
-    #         ]
-    #         if field in self._OPTIONAL_FILTERS_STRING_TO_BOOL
-    #         else self.params.get(field)
-    #     )
-
-    #     if value_list:
-    #         # The most common property for data is to not have a child element
-    #         if not self._has_child(field):
-    #             term_list_container = {"terms": {es_field_name: []}}
-
-    #             term_list_container["terms"][es_field_name] = value_list
-
-    #             return term_list_container
-    #         else:
-    #             item_dict = OrderedDict()
-    #             for v in value_list:
-    #                 v_pair = v.split(DELIMITER)
-    #                 item_dict.setdefault(v_pair[0], [])
-    #                 if len(v_pair) == 2:
-    #                     # put subproduct into list
-    #                     item_dict[v_pair[0]].append(v_pair[1])
-
-    #             # Go through item_dict to create filters
-    #             f_list = []
-    #             for item, child in item_dict.items():
-    #                 # Always append the item to list
-    #                 parent_term = {"terms": {es_field_name: [item]}}
-    #                 if not child:
-    #                     f_list.append(parent_term)
-    #                 else:
-    #                     child_term = {"terms": {
-    #                         self._get_es_name(self._get_child(field)): child
-    #                     }}
-    #                     parent_child_bool_structure = {"bool": {
-    #                         "must": [], "should": []
-    #                     }}
-    #                     parent_child_bool_structure["bool"]["must"].append(
-    #                         parent_term)
-    #                     parent_child_bool_structure["bool"]["should"].append(
-    #                         child_term)
-
-    #                     f_list.append(parent_child_bool_structure)
-
-    #             return f_list
-
-    # # This creates a dictionary of all filter_clauses, where the keys are the
-    # # field name
-    # def _build_filter_clauses(self):
-    #     filter_clauses = {}
-    #     for item in self.params:
-    #         if item in (self._OPTIONAL_FILTERS +
-    #                     self._OPTIONAL_FILTERS_STRING_TO_BOOL):
-    #             filter_clauses[item] = self._build_bool_clauses(item)
-    #     return filter_clauses
-
-    # def _build_date_range_filter(self, date_min, date_max, es_field_name):
-    #     date_clause = {}
-    #     timeSuffix = u'T12:00:00-05:00'
-    #     if date_min or date_max:
-    #         date_clause = {"range": {es_field_name: {}}}
-    #         if date_min:
-    #             d = str(date_min) + timeSuffix
-    #             date_clause["range"][es_field_name]["from"] = d
-    #         if date_max:
-    #             d = str(date_max) + timeSuffix
-    #             date_clause["range"][es_field_name]["to"] = d
-
-    #     return date_clause
 
 
 class SearchBuilder(BaseBuilder):
@@ -385,41 +312,6 @@ class SearchBuilder(BaseBuilder):
 
 class PostFilterBuilder(BaseBuilder):
 
-    # def build(self):
-    #     filter_clauses = self._build_filter_clauses()
-
-    #     post_filter = {"bool": {"should": [], "must": [], "filter": []}}
-
-    #     # date_received
-    #     date_received = self._build_date_range_filter(
-    #         self.params.get("date_received_min"),
-    #         self.params.get("date_received_max"),
-    #         "date_received")
-
-    #     if date_received:
-    #         post_filter["bool"]["filter"].append(date_received)
-
-    #     # company_received
-    #     company_received = self._build_date_range_filter(
-    #         self.params.get("company_received_min"),
-    #         self.params.get("company_received_max"),
-    #         "date_sent_to_company")
-
-    #     if company_received:
-    #         post_filter["bool"]["filter"].append(company_received)
-
-    #     # Create filter clauses for all other filters
-    #     for item in self.params:
-    #         if item in (
-    #             self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-    #         ):
-    #             # for filters selected, we are creating the field level OR
-    #             # query that must match e.g (this OR that) AND (y or z) AND
-    #             # servicemember
-    #             field_level_should = {"bool": {"should": filter_clauses[item]}}
-    #             post_filter["bool"]["filter"].append(field_level_should)
-
-    #     return post_filter
     def build(self):
         include_clauses, exclude_clauses = self._build_clauses_dictionary()
         return self._build_dsl_filter(include_clauses, exclude_clauses)
@@ -441,126 +333,6 @@ class AggregationBuilder(BaseBuilder):
         'timely',
         'zip_code'
     )
-
-    # def __init__(self):
-    #     BaseBuilder.__init__(self)
-    #     self.include_clauses = None
-    #     self.exclude_clauses = None
-    #     self.exclude = []
-
-    # def add_exclude(self, field_name_list):
-    #     self.exclude += field_name_list
-
-    # def build_one(self, field_name):
-    #     # Lazy initialization
-    #     if not self.filter_clauses:
-    #         self.filter_clauses = self._build_filter_clauses()
-
-    #     field_aggs = {
-    #         "filter": {
-    #             "bool": {
-    #                 "must": [],
-    #                 "should": [],
-    #                 "filter": [],
-    #             }
-    #         }
-    #     }
-
-    #     es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
-    #         field_name, field_name
-    #     )
-    #     es_child_name = None
-    #     if field_name in self._OPTIONAL_FILTERS_CHILD_MAP:
-    #         es_child_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
-    #             self._OPTIONAL_FILTERS_CHILD_MAP.get(field_name))
-    #         field_aggs["aggs"] = {
-    #             field_name: {
-    #                 "terms": {
-    #                     "field": es_field_name,
-    #                     "size": 0
-    #                 },
-    #                 "aggs": {
-    #                     es_child_name: {
-    #                         "terms": {
-    #                             "field": es_child_name,
-    #                             "size": 0
-    #                         }
-    #                     }
-    #                 }
-    #             }
-    #         }
-    #     else:
-    #         field_aggs["aggs"] = {
-    #             field_name: {
-    #                 "terms": {
-    #                     "field": es_field_name,
-    #                     "size": 0
-    #                 }
-    #             }
-    #         }
-
-    #     date_filter = self._build_date_range_filter(
-    #         self.params.get("date_received_min"),
-    #         self.params.get("date_received_max"), "date_received")
-
-    #     if date_filter:
-    #         field_aggs["filter"]["bool"]["filter"].append(date_filter)
-
-    #     company_filter = self._build_date_range_filter(
-    #         self.params.get("company_received_min"),
-    #         self.params.get("company_received_max"), "date_sent_to_company")
-
-    #     if company_filter:
-    #         field_aggs["filter"]["bool"]["filter"].append(company_filter)
-
-    #     # Add filter clauses to aggregation entries (only those that are not
-    #     # the same as field name or part of the exclude list, which means we
-    #     # want to list all matched aggregation)
-    #     for item in self.params:
-    #         include_filter = (
-    #             item != field_name or
-    #             (item == field_name and item in self.exclude)
-    #         )
-
-    #         if include_filter and item in (
-    #             self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-    #         ):
-    #             field_level_should = {
-    #                 "bool": {"should": self.filter_clauses[item]}
-    #             }
-    #             field_aggs["filter"]["bool"]["filter"].append(
-    #                 field_level_should
-    #             )
-
-    #     return field_aggs
-
-    # def build(self):
-    #     aggs = {}
-
-    #     agg_fields = self._AGG_FIELDS
-    #     if self.exclude:
-    #         agg_fields = [field_name for field_name in self._AGG_FIELDS
-    #                       if field_name not in self.exclude
-    #                       or field_name in self.params]
-    #     for field_name in agg_fields:
-    #         aggs[field_name] = self.build_one(field_name)
-
-    #     return aggs
-
-    _AGG_HEADING_MAP = {
-        'collection': "Collections",
-        'company': "Matched Company",
-        'company_response': "Company Response",
-        'consumer_disputed': "Consumer Disputed?",
-        'consent_status': "Consumer consent provided?",
-        'issue': "Issue",
-        'older_american': "Older American",
-        'product': "Product",
-        "referred_by": "Referred By",
-        "referred_to": "Referred To",
-        'service_member': "Servicemember",
-        'status': "Status",
-    }
 
     def __init__(self):
         BaseBuilder.__init__(self)
@@ -598,41 +370,25 @@ class AggregationBuilder(BaseBuilder):
                 self._build_clauses_dictionary()
 
         field_aggs = {}
-        census_year = self.params.get("census_year")
 
         es_field_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
             field_name, field_name
         )
-        agg_heading_name = self.header_name(field_name)
         es_child_name = None
 
         if field_name in self._OPTIONAL_FILTERS_CHILD_MAP:
             es_child_name = self._OPTIONAL_FILTERS_PARAM_TO_ES_MAP.get(
                 self._OPTIONAL_FILTERS_CHILD_MAP.get(field_name))
             field_aggs["aggs"] = self.build_parent_child_field_agg(
-                agg_heading_name,
+                field_name,
                 es_field_name,
                 es_child_name
             )
-
-        elif field_name == 'company':
-            field_aggs["aggs"] = {
-                "Matched Company": {
-                    "terms": {
-                        "field": "company_name",
-                        "size": 0
-                    }
-                }
-            }
-
         else:
-            # Note: if/when we move to a single shard for aggregations,
-            # we can use 'size: size' for variable-length aggregations
             field_aggs["aggs"] = {
-                agg_heading_name: {
+                field_name: {
                     "terms": {
                         "field": es_field_name,
-                        # "size": size,
                         "size": 0
                     }
                 }
@@ -648,18 +404,12 @@ class AggregationBuilder(BaseBuilder):
 
         agg_fields = self._AGG_FIELDS
         if self.exclude:
-            agg_fields = [
-                field_name for field_name in self._AGG_FIELDS
-                if field_name not in self.exclude or field_name in self.params
-            ]
+            agg_fields = [field_name for field_name in self._AGG_FIELDS
+                          if field_name not in self.exclude]
         for field_name in agg_fields:
-            aggs[self._AGG_HEADING_MAP.get(field_name, field_name)] = \
-                self.build_one(field_name)
+            aggs[field_name] = self.build_one(field_name)
 
         return aggs
-
-    def header_name(self, field_name):
-        return self._AGG_HEADING_MAP.get(field_name, field_name)
 
 
 class StateAggregationBuilder(BaseBuilder):
@@ -692,11 +442,7 @@ class StateAggregationBuilder(BaseBuilder):
 
         field_aggs = {
             "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [],
-                }
+
             }
         }
 
@@ -729,31 +475,6 @@ class StateAggregationBuilder(BaseBuilder):
                 }
             }
 
-        # date_filter = self._build_date_range_filter(
-        #     self.params.get("date_received_min"),
-        #     self.params.get("date_received_max"), "date_received")
-
-        # if date_filter:
-        #     field_aggs["filter"]["bool"]["filter"].append(date_filter)
-
-        # company_filter = self._build_date_range_filter(
-        #     self.params.get("company_received_min"),
-        #     self.params.get("company_received_max"), "date_sent_to_company")
-
-        # if company_filter:
-        #     field_aggs["filter"]["bool"]["filter"].append(company_filter)
-
-        # for item in self.params:
-        #     if item in (
-        #         self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-        #     ) and not (field_name == 'state' and item == 'state'):
-        #         field_level_should = {
-        #             "bool": {"should": self.filter_clauses[item]}
-        #         }
-        #         field_aggs["filter"]["bool"]["filter"].append(
-        #             field_level_should
-        #         )
-
         field_aggs['filter'] = self._build_dsl_filter(self.include_clauses,
                                                       self.exclude_clauses)
 
@@ -781,10 +502,6 @@ class LensAggregationBuilder(BaseBuilder):
         'tags': 'tags'
     }
 
-    # def __init__(self):
-    #     super(LensAggregationBuilder, self).__init__()
-    #     self.filter_clauses = None
-    #     self.exclude = []
     def __init__(self):
         super(LensAggregationBuilder, self).__init__()
         self._include_clauses = None
@@ -812,48 +529,6 @@ class LensAggregationBuilder(BaseBuilder):
                 }
             }
         }
-
-        # # Lazy initialization
-        # if not self.filter_clauses:
-        #     # self.filter_clauses = self._build_filter_clauses()
-        #     self.filter_clauses = self._build_dsl_filter()
-
-        # filters = {
-        #     "filter": {
-        #         "bool": {
-        #             "must": [],
-        #             "should": [],
-        #             "filter": [],
-        #         }
-        #     }
-        # }
-
-        # date_filter = self._build_date_range_filter(
-        #     self.params.get("date_received_min"),
-        #     self.params.get("date_received_max"), "date_received")
-
-        # if date_filter and include_date_filter:
-        #     filters["filter"]["bool"]["filter"].append(date_filter)
-
-        # company_filter = self._build_date_range_filter(
-        #     self.params.get("company_received_min"),
-        #     self.params.get("company_received_max"), "date_sent_to_company")
-
-        # if company_filter:
-        #     filters["filter"]["bool"]["filter"].append(company_filter)
-
-        # for item in self.params:
-        #     if item in (
-        #         self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-        #     ):
-        #         field_level_should = {
-        #             "bool": {"should": self.filter_clauses[item]}
-        #         }
-        #         filters["filter"]["bool"]["filter"].append(
-        #             field_level_should
-        #         )
-
-        # agg['filter'] = filters['filter']
 
         # Add filter clauses
         agg['filter'] = self._build_dsl_filter(
@@ -926,48 +601,6 @@ class TrendsAggregationBuilder(LensAggregationBuilder):
 
         field_aggs["aggs"][agg_heading_name] = self.percent_change_agg(
             es_field_name, interval, self.params['trend_depth'])
-
-        # # Lazy initialization
-        # if not self.filter_clauses:
-        #     # self.filter_clauses = self._build_filter_clauses()
-        #     self.filter_clauses = self._build_dsl_filter()
-
-        # filters = {
-        #     "filter": {
-        #         "bool": {
-        #             "must": [],
-        #             "should": [],
-        #             "filter": [],
-        #         }
-        #     }
-        # }
-
-        # date_filter = self._build_date_range_filter(
-        #     self.params.get("date_received_min"),
-        #     self.params.get("date_received_max"), "date_received")
-
-        # if date_filter:
-        #     filters["filter"]["bool"]["filter"].append(date_filter)
-
-        # company_filter = self._build_date_range_filter(
-        #     self.params.get("company_received_min"),
-        #     self.params.get("company_received_max"), "date_sent_to_company")
-
-        # if company_filter:
-        #     filters["filter"]["bool"]["filter"].append(company_filter)
-
-        # for item in self.params:
-        #     if item in (
-        #         self._OPTIONAL_FILTERS + self._OPTIONAL_FILTERS_STRING_TO_BOOL
-        #     ):
-        #         field_level_should = {
-        #             "bool": {"should": self.filter_clauses[item]}
-        #         }
-        #         filters["filter"]["bool"]["filter"].append(
-        #             field_level_should
-        #         )
-
-        # field_aggs['filter'] = filters['filter']
 
         # Add the filters
         field_aggs['filter'] = self._build_dsl_filter(

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -1,4 +1,8 @@
-from complaint_search.defaults import DATA_SUB_LENS_MAP, PARAMS
+from complaint_search.defaults import (
+    DATA_SUB_LENS_MAP,
+    EXCLUDE_PREFIX,
+    PARAMS
+)
 from localflavor.us.us_states import STATE_CHOICES
 from rest_framework import serializers
 
@@ -45,6 +49,7 @@ class SearchInputSerializer(serializers.Serializer):
         (SORT_CREATED_DATE_DESC, 'Descending Created Date'),
         (SORT_CREATED_DATE_ASC, 'Ascending Created Date'),
     )
+
     format = serializers.ChoiceField(FORMAT_CHOICES, default=PARAMS['format'])
     field = serializers.ChoiceField(FIELD_CHOICES, default=PARAMS['field'])
     size = serializers.IntegerField(
@@ -89,6 +94,30 @@ class SearchInputSerializer(serializers.Serializer):
         child=serializers.CharField(max_length=200), required=False)
     no_aggs = serializers.BooleanField(default=PARAMS['no_aggs'])
     no_highlight = serializers.BooleanField(default=PARAMS['no_highlight'])
+
+    # oh these had to be Python variables
+    # couldn't just get away with a '-' prefix >:(
+    not_company = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_company_public_response = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_company_response = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_consumer_consent_provided = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_consumer_disputed = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_issue = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_product = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_state = serializers.ListField(
+        child=serializers.ChoiceField(STATE_CHOICES), required=False)
+    not_tags = serializers.ListField(
+        child=serializers.CharField(max_length=200), required=False)
+    not_zip = serializers.ListField(
+        child=serializers.CharField(min_length=5, max_length=5),
+        required=False)
 
     def to_internal_value(self, data):
         ret = super(SearchInputSerializer, self).to_internal_value(data)

--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -1,8 +1,4 @@
-from complaint_search.defaults import (
-    DATA_SUB_LENS_MAP,
-    EXCLUDE_PREFIX,
-    PARAMS
-)
+from complaint_search.defaults import DATA_SUB_LENS_MAP, PARAMS
 from localflavor.us.us_states import STATE_CHOICES
 from rest_framework import serializers
 

--- a/complaint_search/tests/expected_results/search_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_agg_exclude__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,91 +22,38 @@
     "timely",
     "zip_code"
   ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
   "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
-        }
-      }
-    },
-    "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_public_response": {
-          "terms": {
-            "field": "company_public_response.raw",
-            "size": 0
-          }
-        }
-      }
-    },
-    "product": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
-        }
-      }
-    },
     "company": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company": {
           "terms": {
@@ -120,33 +61,47 @@
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+          "must": [],
+          "must_not": []
         }
-      },
+      }
+    },
+    "company_public_response": {
       "aggs": {
-        "consumer_disputed": {
+        "company_public_response": {
           "terms": {
-            "field": "consumer_disputed.raw",
+            "field": "company_public_response.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -154,33 +109,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+          "must": [],
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -188,33 +141,15 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -230,49 +165,101 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
         }
       },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
       "aggs": {
-        "company_response": {
+        "state": {
           "terms": {
-            "field": "company_response",
+            "field": "state",
             "size": 0
           }
         }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
       }
     }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [],
-      "must": [],
-      "should": []
-    }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_no_highlight__valid.json
+++ b/complaint_search/tests/expected_results/search_no_highlight__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,32 +22,30 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
-        }
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
       }
-    },
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -61,92 +53,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "tags": {
+        "company_response": {
           "terms": {
-            "field": "tags",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "company": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company": {
-          "terms": {
-            "field": "company.raw",
-            "size": 0
-          }
-        }
-      }
-    },
-    "consumer_disputed": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -154,33 +85,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+          "must": [],
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -188,33 +117,15 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -230,58 +141,101 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
         }
       },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
       "aggs": {
-        "zip_code": {
+        "state": {
           "terms": {
-            "field": "zip_code",
+            "field": "state",
             "size": 0
           }
         }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
       }
     }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [],
-      "must": [],
-      "should": []
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_no_param__valid.json
+++ b/complaint_search/tests/expected_results/search_no_param__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,32 +22,38 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
-        }
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
       }
-    },
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -61,92 +61,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "tags": {
+        "company_response": {
           "terms": {
-            "field": "tags",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "company": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company": {
-          "terms": {
-            "field": "company.raw",
-            "size": 0
-          }
-        }
-      }
-    },
-    "consumer_disputed": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -154,33 +93,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+          "must": [],
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -188,33 +125,15 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -230,66 +149,101 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
         }
       },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
       "aggs": {
-        "zip_code": {
+        "state": {
           "terms": {
-            "field": "zip_code",
+            "field": "state",
             "size": 0
           }
         }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
       }
     }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [],
-      "must": [],
-      "should": []
-    }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_company__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,439 +22,336 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "company.raw": [
+              "Bank 1",
+              "Second Bank"
+            ]
+          }
         }
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {
-      "bool": {
-        "filter": [
-          {
-            "bool": {
-              "should": {
-                "terms": {
-                  "company.raw": [
-                    "Bank 1",
-                    "Second Bank"
-                  ]
-                }
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
               }
             }
           }
-        ],
-        "must": [],
-        "should": []
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
       }
     },
-    "aggs": {
-        "has_narrative": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "should": [],
-                    "must": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
+    "product": {
+      "aggs": {
         "product": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
+          "terms": {
+            "field": "product.raw",
+            "size": 0
           },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
             }
-        },
-        "issue": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
+          }
         }
-
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_company_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_agg_exclude__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,452 +22,361 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "company.raw": [
+              "Bank 1",
+              "Second Bank"
+            ]
+          }
         }
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {
-      "bool": {
-        "filter": [
-          {
-            "bool": {
-              "should": {
-                "terms": {
-                  "company.raw": [
-                    "Bank 1",
-                    "Second Bank"
-                  ]
-                }
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
               }
             }
           }
-        ],
-        "must": [],
-        "should": []
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
       }
     },
-    "aggs": {
-        "has_narrative": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-                    "should": [],
-                    "must": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
+    "product": {
+      "aggs": {
         "product": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
+          "terms": {
+            "field": "product.raw",
+            "size": 0
           },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
             }
-        },
-        "issue": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-          "filter": {
-            "bool": {
-              "filter": [
-                {
-                  "bool": {
-                    "should": {
-                      "terms": {
-                        "company.raw": [
-                          "Bank 1",
-                          "Second Bank"
-                        ]
-                      }
-                    }
-                  }
-                }
-              ],
-              "should": [],
-              "must": []
-            }
-          },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
+          }
         }
-
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "zip_code": {
+      "aggs": {
+        "zip_code": {
+          "terms": {
+            "field": "zip_code",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company.raw": [
+                  "Bank 1",
+                  "Second Bank"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_public_response__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,45 +22,47 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "company_public_response.raw": [
+              "Company chooses not to provide a public response",
+              "Company believes it acted appropriately as authorized by contract or law"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -74,157 +70,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -232,59 +120,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -292,59 +170,24 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -360,84 +203,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_public_response.raw": [
-                      "Company chooses not to provide a public response",
-                      "Company believes it acted appropriately as authorized by contract or law"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "company_public_response.raw": [
                   "Company chooses not to provide a public response",
@@ -445,20 +215,143 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_public_response.raw": [
+                  "Company chooses not to provide a public response",
+                  "Company believes it acted appropriately as authorized by contract or law"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_company_received_max__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_received_max__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,382 +22,324 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {
-        "bool": {
-            "filter": [
-                {
-                    "range": {
-                        "date_sent_to_company": {
-                            "to": "2017-04-14T12:00:00-05:00"
-                        }
-                    }
-                }
-            ],
-            "must": [],
-            "should": []
-        }
-    },
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "range": {
+            "date_sent_to_company": {
+              "to": "2017-04-14"
+            }
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_company_received_min__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_received_min__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,382 +22,324 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {
-        "bool": {
-            "filter": [
-                {
-                    "range": {
-                        "date_sent_to_company": {
-                            "from": "2014-04-14T12:00:00-05:00"
-                        }
-                    }
-                }
-            ],
-            "must": [],
-            "should": []
-        }
-    },
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_sent_to_company": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "range": {
+            "date_sent_to_company": {
+              "from": "2014-04-14"
+            }
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "date_sent_to_company": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_company_response__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_response__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,58 +22,47 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "company_response": [
+              "Closed",
+              "Closed with non-monetary relief"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -87,157 +70,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -245,59 +120,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -305,59 +170,24 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -373,71 +203,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
       },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "company_response": [
-                      "Closed",
-                      "Closed with non-monetary relief"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "company_response": [
                   "Closed",
@@ -445,20 +215,143 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "company_response": [
+                  "Closed",
+                  "Closed with non-monetary relief"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
+++ b/complaint_search/tests/expected_results/search_with_consumer_consent_provided__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,56 +22,46 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "consumer_consent_provided.raw": [
+              "Consent provided"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -85,140 +69,47 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -226,57 +117,47 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -284,57 +165,23 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -350,102 +197,149 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "consumer_consent_provided.raw": [
-                      "Consent provided"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "consumer_consent_provided.raw": [
                   "Consent provided"
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "consumer_consent_provided.raw": [
+                  "Consent provided"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_date_received_max__valid.json
+++ b/complaint_search/tests/expected_results/search_with_date_received_max__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,381 +22,324 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {
-        "bool": {
-            "filter": [
-                {
-                    "range": {
-                        "date_received": {
-                            "to": "2017-04-14T12:00:00-05:00"
-                        }
-                    }
-                }
-            ],
-            "must": [],
-            "should": []
-        }
-    },
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "to": "2017-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "range": {
+            "created_time": {
+              "to": "2017-04-14"
+            }
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "to": "2017-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_date_received_min__valid.json
+++ b/complaint_search/tests/expected_results/search_with_date_received_min__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,382 +22,324 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {
-        "bool": {
-            "filter": [
-                {
-                    "range": {
-                        "date_received": {
-                            "from": "2014-04-14T12:00:00-05:00"
-                        }
-                    }
-                }
-            ],
-            "must": [],
-            "should": []
-        }
-    },
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "must": [],
-                    "should": [],
-                    "filter": [
-                        {
-                            "range": {
-                                "date_received": {
-                                    "from": "2014-04-14T12:00:00-05:00"
-                                }
-                            }
-                        }
-                    ]
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "range": {
+            "created_time": {
+              "from": "2014-04-14"
+            }
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "range": {
+                "created_time": {
+                  "from": "2014-04-14"
+                }
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_field__valid.json
+++ b/complaint_search/tests/expected_results/search_with_field__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,265 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "test_field"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "test_field": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "test_field"
+      ],
+      "default_operator": "AND"
     }
-
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "test_field": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_field_all__valid.json
+++ b/complaint_search/tests/expected_results/search_with_field_all__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,282 +22,246 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "_all"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "sub_product": {},
-            "date_sent_to_company": {},
-            "complaint_id": {},
-            "consumer_consent_provided": {},
-            "date_received": {},
-            "state": {},
-            "issue": {},
-            "company_response": {},
-            "zip_code": {},
-            "timely": {},
-            "product": {},
-            "complaint_what_happened": {},
-            "company": {},
-            "sub_issue": {},
-            "tags": {},
-            "company_public_response": {},
-            "consumer_disputed": {},
-            "has_narrative": {},
-            "submitted_via": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[]}},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "_all"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "company": {},
+      "company_public_response": {},
+      "company_response": {},
+      "complaint_id": {},
+      "complaint_what_happened": {},
+      "consumer_consent_provided": {},
+      "consumer_disputed": {},
+      "date_received": {},
+      "date_sent_to_company": {},
+      "has_narrative": {},
+      "issue": {},
+      "product": {},
+      "state": {},
+      "submitted_via": {},
+      "sub_issue": {},
+      "sub_product": {},
+      "tags": {},
+      "timely": {},
+      "zip_code": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_frm__valid.json
+++ b/complaint_search/tests/expected_results/search_with_frm__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 20,
+  "from": 20,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
+++ b/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,56 +22,38 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
-        }
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
       }
-    },
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -85,152 +61,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "tags": {
+        "company_response": {
           "terms": {
-            "field": "tags",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "company": {
+      },
       "filter": {
         "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company": {
-          "terms": {
-            "field": "company.raw",
-            "size": 0
-          }
-        }
-      }
-    },
-    "consumer_disputed": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -238,45 +93,31 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
+          "must": [],
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -284,57 +125,15 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -350,102 +149,101 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
+          "must": [],
+          "must_not": []
         }
       }
     },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "has_narrative": [
-                      1
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "product": {
       "aggs": {
-        "zip_code": {
+        "product": {
           "terms": {
-            "field": "zip_code",
+            "field": "product.raw",
             "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
+          },
+          "aggs": {
+            "sub_product.raw": {
               "terms": {
-                "has_narrative": [
-                  1
-                ]
+                "field": "sub_product.raw",
+                "size": 0
               }
             }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_issue__valid.json
+++ b/complaint_search/tests/expected_results/search_with_issue__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,51 +22,68 @@
     "timely",
     "zip_code"
   ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "issue.raw": "Communication tactics"
+                      }
+                    },
+                    {
+                      "terms": {
+                        "sub_issue.raw": [
+                          "Frequent or repeated calls"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "term": {
+                  "issue.raw": "Loan servicing, payments, escrow account"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
   "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_issue.raw": [
-                              "Frequent or repeated calls"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -80,18 +91,21 @@
             "size": 0
           }
         }
-      }
-    },
-    "timely": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_issue.raw": [
@@ -99,52 +113,45 @@
                             ]
                           }
                         }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
                       ]
                     }
                   },
                   {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
                     }
                   }
                 ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "product": {
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_issue.raw": [
@@ -152,253 +159,23 @@
                             ]
                           }
                         }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
                       ]
                     }
                   },
                   {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
                     }
                   }
                 ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "state": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_issue.raw": [
-                              "Frequent or repeated calls"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "state": {
-          "terms": {
-            "field": "state",
-            "size": 0
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_issue.raw": [
-                              "Frequent or repeated calls"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
-        }
-      }
-    },
-    "consumer_disputed": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_issue.raw": [
-                              "Frequent or repeated calls"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_issue.raw": [
-                              "Frequent or repeated calls"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -406,18 +183,21 @@
             "size": 0
           }
         }
-      }
-    },
-    "has_narrative": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_issue.raw": [
@@ -425,12 +205,49 @@
                             ]
                           }
                         }
-                      ],
+                      ]
+                    }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
                       "must": [
                         {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
                           "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
                             ]
                           }
                         }
@@ -438,20 +255,19 @@
                     }
                   },
                   {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
                     }
                   }
                 ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "has_narrative": {
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -459,16 +275,45 @@
             "size": 0
           }
         }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -484,18 +329,21 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_issue.raw": [
@@ -503,12 +351,57 @@
                             ]
                           }
                         }
-                      ],
+                      ]
+                    }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
                       "must": [
                         {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
                           "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
                             ]
                           }
                         }
@@ -516,73 +409,65 @@
                     }
                   },
                   {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
                     }
                   }
                 ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "state": {
       "aggs": {
-        "company_response": {
+        "state": {
           "terms": {
-            "field": "company_response",
+            "field": "state",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "submitted_via": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_issue.raw": [
-                              "Frequent or repeated calls"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "issue.raw": [
-                              "Communication tactics"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "terms": {
-                      "issue.raw": [
-                        "Loan servicing, payments, escrow account"
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "submitted_via": {
           "terms": {
@@ -590,68 +475,135 @@
             "size": 0
           }
         }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": [
-              {
-                "bool": {
-                  "should": [
-                    {
-                      "terms": {
-                        "sub_issue.raw": [
-                          "Frequent or repeated calls"
-                        ]
-                      }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
+                            ]
+                          }
+                        }
+                      ]
                     }
-                  ],
-                  "must": [
-                    {
-                      "terms": {
-                        "issue.raw": [
-                          "Communication tactics"
-                        ]
-                      }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
                     }
-                  ]
-                }
-              },
-              {
-                "terms": {
-                  "issue.raw": [
-                    "Loan servicing, payments, escrow account"
-                  ]
-                }
+                  }
+                ]
               }
-            ]
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "issue.raw": "Communication tactics"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_issue.raw": [
+                              "Frequent or repeated calls"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "term": {
+                      "issue.raw": "Loan servicing, payments, escrow account"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_not_company__valid.json
+++ b/complaint_search/tests/expected_results/search_with_not_company__valid.json
@@ -1,0 +1,345 @@
+{
+  "from": 0,
+  "size": 10,
+  "_source": [
+    "company",
+    "company_public_response",
+    "company_response",
+    "complaint_id",
+    "complaint_what_happened",
+    "consumer_consent_provided",
+    "consumer_disputed",
+    "date_received",
+    "date_sent_to_company",
+    "has_narrative",
+    "issue",
+    "product",
+    "state",
+    "submitted_via",
+    "sub_issue",
+    "sub_product",
+    "tags",
+    "timely",
+    "zip_code"
+  ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": [
+        {
+          "terms": {
+            "company.raw": [
+              "EQUIFAX, INC."
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "terms": {
+                "company.raw": [
+                  "EQUIFAX, INC."
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/complaint_search/tests/expected_results/search_with_not_issue__valid.json
+++ b/complaint_search/tests/expected_results/search_with_not_issue__valid.json
@@ -1,0 +1,393 @@
+{
+  "from": 0,
+  "size": 10,
+  "_source": [
+    "company",
+    "company_public_response",
+    "company_response",
+    "complaint_id",
+    "complaint_what_happened",
+    "consumer_consent_provided",
+    "consumer_disputed",
+    "date_received",
+    "date_sent_to_company",
+    "has_narrative",
+    "issue",
+    "product",
+    "state",
+    "submitted_via",
+    "sub_issue",
+    "sub_product",
+    "tags",
+    "timely",
+    "zip_code"
+  ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": [
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "issue.raw": "Incorrect information on your report"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "issue.raw": "Incorrect information on your report"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/complaint_search/tests/expected_results/search_with_not_product__valid.json
+++ b/complaint_search/tests/expected_results/search_with_not_product__valid.json
@@ -1,0 +1,609 @@
+{
+  "from": 0,
+  "size": 10,
+  "_source": [
+    "company",
+    "company_public_response",
+    "company_response",
+    "complaint_id",
+    "complaint_what_happened",
+    "consumer_consent_provided",
+    "consumer_disputed",
+    "date_received",
+    "date_sent_to_company",
+    "has_narrative",
+    "issue",
+    "product",
+    "state",
+    "submitted_via",
+    "sub_issue",
+    "sub_product",
+    "tags",
+    "timely",
+    "zip_code"
+  ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": [
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "product.raw": "Mortgage"
+                      }
+                    },
+                    {
+                      "terms": {
+                        "sub_product.raw": [
+                          "FHA mortgage"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/complaint_search/tests/expected_results/search_with_product__valid.json
+++ b/complaint_search/tests/expected_results/search_with_product__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,51 +22,68 @@
     "timely",
     "zip_code"
   ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "product.raw": "Payday loan"
+                }
+              },
+              {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "product.raw": "Mortgage"
+                      }
+                    },
+                    {
+                      "terms": {
+                        "sub_product.raw": [
+                          "FHA mortgage"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
   "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
-                    }
-                  },
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_product.raw": [
-                              "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -80,38 +91,30 @@
             "size": 0
           }
         }
-      }
-    },
-    "timely": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
+                    "term": {
+                      "product.raw": "Payday loan"
                     }
                   },
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_product.raw": [
                               "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
                             ]
                           }
                         }
@@ -122,74 +125,42 @@
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "product": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "product": {
+        "company_response": {
           "terms": {
-            "field": "product.raw",
+            "field": "company_response",
             "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
+                    "term": {
+                      "product.raw": "Payday loan"
                     }
                   },
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_product.raw": [
                               "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
                             ]
                           }
                         }
@@ -200,169 +171,11 @@
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "state": {
-          "terms": {
-            "field": "state",
-            "size": 0
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
-                    }
-                  },
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_product.raw": [
-                              "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
-        }
-      }
-    },
-    "consumer_disputed": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
-                    }
-                  },
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_product.raw": [
-                              "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
-                    }
-                  },
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_product.raw": [
-                              "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -370,38 +183,30 @@
             "size": 0
           }
         }
-      }
-    },
-    "has_narrative": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
+                    "term": {
+                      "product.raw": "Payday loan"
                     }
                   },
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_product.raw": [
                               "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
                             ]
                           }
                         }
@@ -412,10 +217,57 @@
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
         }
       },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Payday loan"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -423,38 +275,30 @@
             "size": 0
           }
         }
-      }
-    },
-    "issue": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
+                    "term": {
+                      "product.raw": "Payday loan"
                     }
                   },
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_product.raw": [
                               "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
                             ]
                           }
                         }
@@ -465,10 +309,11 @@
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "issue": {
       "aggs": {
         "issue": {
           "terms": {
@@ -484,38 +329,30 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
               "bool": {
                 "should": [
                   {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
+                    "term": {
+                      "product.raw": "Payday loan"
                     }
                   },
                   {
                     "bool": {
-                      "should": [
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
                         {
                           "terms": {
                             "sub_product.raw": [
                               "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
                             ]
                           }
                         }
@@ -526,63 +363,111 @@
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
         }
       },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Payday loan"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
       "aggs": {
-        "company_response": {
+        "state": {
           "terms": {
-            "field": "company_response",
+            "field": "state",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Payday loan"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "submitted_via": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": [
-                  {
-                    "terms": {
-                      "product.raw": [
-                        "Payday loan"
-                      ]
-                    }
-                  },
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "terms": {
-                            "sub_product.raw": [
-                              "FHA mortgage"
-                            ]
-                          }
-                        }
-                      ],
-                      "must": [
-                        {
-                          "terms": {
-                            "product.raw": [
-                              "Mortgage"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "submitted_via": {
           "terms": {
@@ -590,68 +475,135 @@
             "size": 0
           }
         }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": [
-              {
-                "terms": {
-                  "product.raw": [
-                    "Payday loan"
-                  ]
-                }
-              },
-              {
-                "bool": {
-                  "should": [
-                    {
-                      "terms": {
-                        "sub_product.raw": [
-                          "FHA mortgage"
-                        ]
-                      }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Payday loan"
                     }
-                  ],
-                  "must": [
-                    {
-                      "terms": {
-                        "product.raw": [
-                          "Mortgage"
-                        ]
-                      }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
                     }
-                  ]
-                }
+                  }
+                ]
               }
-            ]
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Payday loan"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "product.raw": "Payday loan"
+                    }
+                  },
+                  {
+                    "bool": {
+                      "must": [
+                        {
+                          "term": {
+                            "product.raw": "Mortgage"
+                          }
+                        },
+                        {
+                          "terms": {
+                            "sub_product.raw": [
+                              "FHA mortgage"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_match__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,263 +22,227 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "match": {
-            "complaint_what_happened": {
-                "query": "test term",
-                "operator": "and"
-            }
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "match": {
+      "complaint_what_happened": {
+        "query": "test term",
+        "operator": "and"
+      }
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_and__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "test AND term",
-            "fields": [
-                    "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "test AND term",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_not__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "test NOT term",
-            "fields": [
-                    "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "test NOT term",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_or__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "test OR term",
-            "fields": [
-                    "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "test OR term",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
+++ b/complaint_search/tests/expected_results/search_with_search_term_qsq_to__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "term TO test",
-            "fields": [
-                    "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "term TO test",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_size__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 40,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 40,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_size_corrected__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size_corrected__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 100,
   "_source": [
     "company",
     "company_public_response",
@@ -21,264 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 100,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "sort": [{"_score": {"order": "desc"}}],
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_sort__valid.json
+++ b/complaint_search/tests/expected_results/search_with_sort__valid.json
@@ -1,5 +1,6 @@
 {
-    "from": 0,
+  "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -21,263 +22,228 @@
     "timely",
     "zip_code"
   ],
-    "size": 10,
-    "query": {
-        "query_string": {
-            "query": "*",
-            "fields": [
-                "complaint_what_happened"
-            ],
-            "default_operator": "AND"
-        }
-    },
-    "highlight": {
-        "require_field_match": false,
-        "fields": {
-            "complaint_what_happened": {}
-        },
-        "number_of_fragments": 1,
-        "fragment_size": 500
-    },
-    "post_filter": {"bool": {"filter": [], "must": [], "should":[] }},
-    "aggs": {
-        "has_narrative": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "has_narrative": {
-                    "terms": {
-                        "field": "has_narrative",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company": {
-                    "terms": {
-                        "field": "company.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "product": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "product": {
-                    "terms": {
-                        "field": "product.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_product.raw": {
-                            "terms": {
-                                "field": "sub_product.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "issue": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "issue": {
-                    "terms": {
-                        "field": "issue.raw",
-                        "size": 0
-                    },
-                    "aggs": {
-                        "sub_issue.raw": {
-                            "terms": {
-                                "field": "sub_issue.raw",
-                                "size": 0
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "state": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "state": {
-                    "terms": {
-                        "field": "state",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "zip_code": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "zip_code": {
-                    "terms": {
-                        "field": "zip_code",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "timely": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "timely": {
-                    "terms": {
-                        "field": "timely",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_response": {
-                    "terms": {
-                        "field": "company_response",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "company_public_response": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "company_public_response": {
-                    "terms": {
-                        "field": "company_public_response.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_disputed": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_disputed": {
-                    "terms": {
-                        "field": "consumer_disputed.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "consumer_consent_provided": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "consumer_consent_provided": {
-                    "terms": {
-                        "field": "consumer_consent_provided.raw",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "tags": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "tags": {
-                    "terms": {
-                        "field": "tags",
-                        "size": 0
-                    }
-                }
-            }
-        },
-        "submitted_via": {
-            "filter": {
-                "bool": {
-                    "filter": [],
-                    "must": [],
-                    "should": []
-                }
-            },
-            "aggs": {
-                "submitted_via": {
-                    "terms": {
-                        "field": "submitted_via",
-                        "size": 0
-                    }
-                }
-            }
-        }
-
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
     }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": []
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    }
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_state__valid.json
+++ b/complaint_search/tests/expected_results/search_with_state__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,60 +22,48 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "state": [
+              "CA",
+              "VA",
+              "OR"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -89,162 +71,51 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -252,47 +123,51 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -300,61 +175,25 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -370,86 +209,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "CA",
-                      "VA",
-                      "OR"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "state": [
                   "CA",
@@ -458,20 +222,148 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "state": [
+                  "CA",
+                  "VA",
+                  "OR"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
+++ b/complaint_search/tests/expected_results/search_with_submitted_via__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,56 +22,46 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "submitted_via": [
+              "Web"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -85,152 +69,47 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
+                "submitted_via": [
+                  "Web"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -238,57 +117,47 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -296,45 +165,23 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -350,102 +197,149 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "submitted_via": [
-                      "Web"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "submitted_via": [
                   "Web"
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "submitted_via": [
+                  "Web"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_tags__valid.json
+++ b/complaint_search/tests/expected_results/search_with_tags__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,58 +22,47 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "tags": [
+              "Older American",
+              "Servicemember"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -87,144 +70,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
-        }
-      }
-    },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company": {
-          "terms": {
-            "field": "company.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "consumer_disputed": {
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -232,59 +120,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -292,59 +170,24 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -360,84 +203,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "tags": [
-                      "Older American",
-                      "Servicemember"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "tags": [
                   "Older American",
@@ -445,20 +215,143 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "tags": [
+                  "Older American",
+                  "Servicemember"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_timely__valid.json
+++ b/complaint_search/tests/expected_results/search_with_timely__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,45 +22,47 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "timely": [
+              "Yes",
+              "No"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -74,157 +70,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -232,59 +120,49 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -292,59 +170,24 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -360,84 +203,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "timely": [
-                      "Yes",
-                      "No"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "timely": [
                   "Yes",
@@ -445,20 +215,143 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "timely": [
+                  "Yes",
+                  "No"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_two_not__valid.json
+++ b/complaint_search/tests/expected_results/search_with_two_not__valid.json
@@ -1,0 +1,597 @@
+{
+  "from": 0,
+  "size": 10,
+  "_source": [
+    "company",
+    "company_public_response",
+    "company_response",
+    "complaint_id",
+    "complaint_what_happened",
+    "consumer_consent_provided",
+    "consumer_disputed",
+    "date_received",
+    "date_sent_to_company",
+    "has_narrative",
+    "issue",
+    "product",
+    "state",
+    "submitted_via",
+    "sub_issue",
+    "sub_product",
+    "tags",
+    "timely",
+    "zip_code"
+  ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [],
+      "must_not": [
+        {
+          "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "term": {
+                        "issue.raw": "Incorrect information on your report"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "term": {
+                        "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "company_public_response": {
+      "aggs": {
+        "company_public_response": {
+          "terms": {
+            "field": "company_public_response.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_consent_provided": {
+      "aggs": {
+        "consumer_consent_provided": {
+          "terms": {
+            "field": "consumer_consent_provided.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "consumer_disputed": {
+      "aggs": {
+        "consumer_disputed": {
+          "terms": {
+            "field": "consumer_disputed.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "has_narrative": {
+      "aggs": {
+        "has_narrative": {
+          "terms": {
+            "field": "has_narrative",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_issue.raw": {
+              "terms": {
+                "field": "sub_issue.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "issue.raw": "Incorrect information on your report"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "product.raw": "Credit reporting, credit repair services, or other personal consumer reports"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/complaint_search/tests/expected_results/search_with_zip_code__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,60 +22,48 @@
     "timely",
     "zip_code"
   ],
-  "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
           "terms": {
-            "field": "timely",
-            "size": 0
+            "zip_code": [
+              "12345",
+              "23435",
+              "03433"
+            ]
           }
         }
-      }
-    },
+      ],
+      "must_not": []
+    }
+  },
+  "aggs": {
     "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company_public_response": {
           "terms": {
@@ -89,162 +71,51 @@
             "size": 0
           }
         }
-      }
-    },
-    "product": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
               "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
-    "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
+    "company_response": {
       "aggs": {
-        "company": {
+        "company_response": {
           "terms": {
-            "field": "company.raw",
+            "field": "company_response",
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -252,61 +123,51 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -314,61 +175,25 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -384,72 +209,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "zip_code": [
                   "12345",
@@ -458,20 +222,148 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/search_with_zip_code_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code_agg_exclude__valid.json
@@ -1,12 +1,6 @@
 {
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
-      }
-    }
-  ],
   "from": 0,
+  "size": 10,
   "_source": [
     "company",
     "company_public_response",
@@ -28,161 +22,48 @@
     "timely",
     "zip_code"
   ],
+  "query": {
+    "query_string": {
+      "query": "*",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "default_operator": "AND"
+    }
+  },
+  "highlight": {
+    "require_field_match": false,
+    "number_of_fragments": 1,
+    "fragment_size": 500,
+    "fields": {
+      "complaint_what_happened": {}
+    }
+  },
+  "sort": [
+    {
+      "_score": {
+        "order": "desc"
+      }
+    }
+  ],
+  "post_filter": {
+    "bool": {
+      "must": [
+        {
+          "terms": {
+            "zip_code": [
+              "12345",
+              "23435",
+              "03433"
+            ]
+          }
+        }
+      ],
+      "must_not": []
+    }
+  },
   "aggs": {
-    "timely": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
-          }
-        }
-      }
-    },
-    "company_public_response": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_public_response": {
-          "terms": {
-            "field": "company_public_response.raw",
-            "size": 0
-          }
-        }
-      }
-    },
-    "product": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
-              }
-            }
-          }
-        }
-      }
-    },
-    "tags": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
-          }
-        }
-      }
-    },
     "company": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "company": {
           "terms": {
@@ -190,61 +71,77 @@
             "size": 0
           }
         }
-      }
-    },
-    "consumer_disputed": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "company_public_response": {
       "aggs": {
-        "consumer_disputed": {
+        "company_public_response": {
           "terms": {
-            "field": "consumer_disputed.raw",
+            "field": "company_public_response.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "company_response": {
+      "aggs": {
+        "company_response": {
+          "terms": {
+            "field": "company_response",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "consumer_consent_provided": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "consumer_consent_provided": {
           "terms": {
@@ -252,61 +149,51 @@
             "size": 0
           }
         }
-      }
-    },
-    "state": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
+          "must_not": []
         }
-      },
+      }
+    },
+    "consumer_disputed": {
       "aggs": {
-        "state": {
+        "consumer_disputed": {
           "terms": {
-            "field": "state",
+            "field": "consumer_disputed.raw",
             "size": 0
           }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
         }
       }
     },
     "has_narrative": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "has_narrative": {
           "terms": {
@@ -314,61 +201,25 @@
             "size": 0
           }
         }
-      }
-    },
-    "submitted_via": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
               }
             }
           ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
-          }
+          "must_not": []
         }
       }
     },
     "issue": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
       "aggs": {
         "issue": {
           "terms": {
@@ -384,86 +235,11 @@
             }
           }
         }
-      }
-    },
-    "company_response": {
+      },
       "filter": {
         "bool": {
-          "filter": [
+          "must": [
             {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
-          }
-        }
-      }
-    },
-    "zip_code": {
-      "filter": {
-        "bool": {
-          "filter": [
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "zip_code": [
-                      "12345",
-                      "23435",
-                      "03433"
-                    ]
-                  }
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must": []
-        }
-      },
-      "aggs": {
-        "zip_code": {
-          "terms": {
-            "field": "zip_code",
-            "size": 0
-          }
-        }
-      }
-    }
-  },
-  "query": {
-    "query_string": {
-      "query": "*",
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ]
-    }
-  },
-  "post_filter": {
-    "bool": {
-      "filter": [
-        {
-          "bool": {
-            "should": {
               "terms": {
                 "zip_code": [
                   "12345",
@@ -472,20 +248,148 @@
                 ]
               }
             }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 0
+          },
+          "aggs": {
+            "sub_product.raw": {
+              "terms": {
+                "field": "sub_product.raw",
+                "size": 0
+              }
+            }
           }
         }
-      ],
-      "must": [],
-      "should": []
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "submitted_via": {
+      "aggs": {
+        "submitted_via": {
+          "terms": {
+            "field": "submitted_via",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "tags": {
+      "aggs": {
+        "tags": {
+          "terms": {
+            "field": "tags",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
+    },
+    "timely": {
+      "aggs": {
+        "timely": {
+          "terms": {
+            "field": "timely",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "terms": {
+                "zip_code": [
+                  "12345",
+                  "23435",
+                  "03433"
+                ]
+              }
+            }
+          ],
+          "must_not": []
+        }
+      }
     }
-  },
-  "highlight": {
-    "fragment_size": 500,
-    "number_of_fragments": 1,
-    "require_field_match": false,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "size": 10
+  }
 }

--- a/complaint_search/tests/expected_results/states_agg__valid.json
+++ b/complaint_search/tests/expected_results/states_agg__valid.json
@@ -1,5 +1,7 @@
 {
-  "_source": [
+        "from": 0,
+        "size": 0,
+        "_source": [
             "company",
             "company_public_response",
             "company_response",
@@ -20,82 +22,77 @@
             "timely",
             "zip_code"
         ],
-  "aggs": {
-    "issue": {
-      "aggs": {
-        "issue": {
-          "terms": {
-            "field": "issue.raw",
-            "size": 5
-          }
-        }
-      },
-      "filter": {
-        "bool": {
-          "filter": [],
-          "must": [],
-          "should": []
-        }
-      }
-    },
-    "product": {
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 5
-          }
-        }
-      },
-      "filter": {
-        "bool": {
-          "filter": [],
-          "must": [],
-          "should": []
-        }
-      }
-    },
-    "state": {
-      "aggs": {
-        "state": {
-          "aggs": {
+        "query": {
+            "query_string": {
+                "query": "*",
+                "fields": [
+                    "complaint_what_happened"
+                ],
+                "default_operator": "AND"
+            }
+        },
+        "aggs": {
             "issue": {
-              "terms": {
-                "field": "issue.raw",
-                "size": 1
-              }
+                "filter": {
+                    "bool": {
+                        "must": [],
+                        "must_not": []
+                    }
+                },
+                "aggs": {
+                    "issue": {
+                        "terms": {
+                            "field": "issue.raw",
+                            "size": 5
+                        }
+                    }
+                }
             },
             "product": {
-              "terms": {
-                "field": "product.raw",
-                "size": 1
-              }
+                "filter": {
+                    "bool": {
+                        "must": [],
+                        "must_not": []
+                    }
+                },
+                "aggs": {
+                    "product": {
+                        "terms": {
+                            "field": "product.raw",
+                            "size": 5
+                        }
+                    }
+                }
+            },
+            "state": {
+                "filter": {
+                    "bool": {
+                        "must": [],
+                        "must_not": []
+                    }
+                },
+                "aggs": {
+                    "state": {
+                        "terms": {
+                            "field": "state",
+                            "size": 0
+                        },
+                        "aggs": {
+                            "product": {
+                                "terms": {
+                                    "field": "product.raw",
+                                    "size": 1
+                                }
+                            },
+                            "issue": {
+                                "terms": {
+                                    "field": "issue.raw",
+                                    "size": 1
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          },
-          "terms": {
-            "field": "state",
-            "size": 0
-          }
         }
-      },
-      "filter": {
-        "bool": {
-          "filter": [],
-          "must": [],
-          "should": []
-        }
-      }
     }
-  },
-  "from": 0,
-  "query": {
-    "query_string": {
-      "default_operator": "AND",
-      "fields": [
-        "complaint_what_happened"
-      ],
-      "query": "*"
-    }
-  },
-  "size": 0
-}

--- a/complaint_search/tests/expected_results/states_date_filters__valid.json
+++ b/complaint_search/tests/expected_results/states_date_filters__valid.json
@@ -1,174 +1,170 @@
 {
-  "from": 0,
-  "size": 0,
-  "_source": [
-    "company",
-    "company_public_response",
-    "company_response",
-    "complaint_id",
-    "complaint_what_happened",
-    "consumer_consent_provided",
-    "consumer_disputed",
-    "date_received",
-    "date_sent_to_company",
-    "has_narrative",
-    "issue",
-    "product",
-    "state",
-    "submitted_via",
-    "sub_issue",
-    "sub_product",
-    "tags",
-    "timely",
-    "zip_code"
-  ],
-  "query": {
-    "query_string": {
-      "query": "*",
-      "fields": [
-        "complaint_what_happened"
-      ],
-      "default_operator": "AND"
-    }
-  },
-  "aggs": {
-    "issue": {
-      "filter": {
-        "bool": {
-          "must": [],
-          "should": [],
-          "filter": [
-            {
-              "range": {
-                "date_received": {
-                  "from": "2020-01-01T12:00:00-05:00",
-                  "to": "2020-05-05T12:00:00-05:00"
-                }
-              }
-            },
-            {
-              "range": {
-                "date_sent_to_company": {
-                  "from": "2020-01-01T12:00:00-05:00",
-                  "to": "2020-05-05T12:00:00-05:00"
-                }
-              }
-            },
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "VA"
-                    ]
-                  }
-                }
-              }
+        "from": 0,
+        "size": 0,
+        "_source": [
+            "company",
+            "company_public_response",
+            "company_response",
+            "complaint_id",
+            "complaint_what_happened",
+            "consumer_consent_provided",
+            "consumer_disputed",
+            "date_received",
+            "date_sent_to_company",
+            "has_narrative",
+            "issue",
+            "product",
+            "state",
+            "submitted_via",
+            "sub_issue",
+            "sub_product",
+            "tags",
+            "timely",
+            "zip_code"
+        ],
+        "query": {
+            "query_string": {
+                "query": "*",
+                "fields": [
+                    "complaint_what_happened"
+                ],
+                "default_operator": "AND"
             }
-          ]
-        }
-      },
-      "aggs": {
-        "issue": {
-          "terms": {
-            "field": "issue.raw",
-            "size": 5
-          }
-        }
-      }
-    },
-    "product": {
-      "filter": {
-        "bool": {
-          "must": [],
-          "should": [],
-          "filter": [
-            {
-              "range": {
-                "date_received": {
-                  "from": "2020-01-01T12:00:00-05:00",
-                  "to": "2020-05-05T12:00:00-05:00"
-                }
-              }
-            },
-            {
-              "range": {
-                "date_sent_to_company": {
-                  "from": "2020-01-01T12:00:00-05:00",
-                  "to": "2020-05-05T12:00:00-05:00"
-                }
-              }
-            },
-            {
-              "bool": {
-                "should": {
-                  "terms": {
-                    "state": [
-                      "VA"
-                    ]
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 5
-          }
-        }
-      }
-    },
-    "state": {
-      "filter": {
-        "bool": {
-          "must": [],
-          "should": [],
-          "filter": [
-            {
-              "range": {
-                "date_received": {
-                  "from": "2020-01-01T12:00:00-05:00",
-                  "to": "2020-05-05T12:00:00-05:00"
-                }
-              }
-            },
-            {
-              "range": {
-                "date_sent_to_company": {
-                  "from": "2020-01-01T12:00:00-05:00",
-                  "to": "2020-05-05T12:00:00-05:00"
-                }
-              }
-            }
-          ]
-        }
-      },
-      "aggs": {
-        "state": {
-          "terms": {
-            "field": "state",
-            "size": 0
-          },
-          "aggs": {
-            "product": {
-              "terms": {
-                "field": "product.raw",
-                "size": 1
-              }
-            },
+        },
+        "aggs": {
             "issue": {
-              "terms": {
-                "field": "issue.raw",
-                "size": 1
-              }
+                "filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "range": {
+                                    "created_time": {
+                                        "from": "2020-01-01",
+                                        "to": "2020-05-05"
+                                    }
+                                }
+                            },
+                            {
+                                "range": {
+                                    "date_sent_to_company": {
+                                        "from": "2020-01-01",
+                                        "to": "2020-05-05"
+                                    }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "state": [
+                                        "VA"
+                                    ]
+                                }
+                            }
+                        ],
+                        "must_not": []
+                    }
+                },
+                "aggs": {
+                    "issue": {
+                        "terms": {
+                            "field": "issue.raw",
+                            "size": 5
+                        }
+                    }
+                }
+            },
+            "product": {
+                "filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "range": {
+                                    "created_time": {
+                                        "from": "2020-01-01",
+                                        "to": "2020-05-05"
+                                    }
+                                }
+                            },
+                            {
+                                "range": {
+                                    "date_sent_to_company": {
+                                        "from": "2020-01-01",
+                                        "to": "2020-05-05"
+                                    }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "state": [
+                                        "VA"
+                                    ]
+                                }
+                            }
+                        ],
+                        "must_not": []
+                    }
+                },
+                "aggs": {
+                    "product": {
+                        "terms": {
+                            "field": "product.raw",
+                            "size": 5
+                        }
+                    }
+                }
+            },
+            "state": {
+                "filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "range": {
+                                    "created_time": {
+                                        "from": "2020-01-01",
+                                        "to": "2020-05-05"
+                                    }
+                                }
+                            },
+                            {
+                                "range": {
+                                    "date_sent_to_company": {
+                                        "from": "2020-01-01",
+                                        "to": "2020-05-05"
+                                    }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "state": [
+                                        "VA"
+                                    ]
+                                }
+                            }
+                        ],
+                        "must_not": []
+                    }
+                },
+                "aggs": {
+                    "state": {
+                        "terms": {
+                            "field": "state",
+                            "size": 0
+                        },
+                        "aggs": {
+                            "product": {
+                                "terms": {
+                                    "field": "product.raw",
+                                    "size": 1
+                                }
+                            },
+                            "issue": {
+                                "terms": {
+                                    "field": "issue.raw",
+                                    "size": 1
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
-}

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -354,6 +354,10 @@ class EsInterfaceTest_Search(TestCase):
         self.request_test("search_with_company__valid",
                           company=["Bank 1", "Second Bank"])
 
+    def test_search_with_not_company__valid(self):
+        self.request_test("search_with_not_company__valid",
+                          not_company=["EQUIFAX, INC."])
+
     def test_search_with_company_agg_exclude__valid(self):
         self.request_test("search_with_company_agg_exclude__valid",
                           agg_exclude=['company'],
@@ -366,12 +370,34 @@ class EsInterfaceTest_Search(TestCase):
             product=["Payday loan", u"Mortgage\u2022FHA mortgage"]
         )
 
+    def test_search_with_not_product__valid(self):
+        self.request_test(
+            "search_with_not_product__valid",
+            not_product=["Credit reporting, credit repair services, or "
+                         "other personal consumer reports",
+                         "Mortgage\u2022FHA mortgage"]
+        )
+
     def test_search_with_issue__valid(self):
         self.request_test(
             "search_with_issue__valid",
             agg_exclude=[u"zip_code", u"company"],
             issue=[u"Communication tactics\u2022Frequent or repeated calls",
                    "Loan servicing, payments, escrow account"]
+        )
+
+    def test_search_with_not_issue__valid(self):
+        self.request_test(
+            "search_with_not_issue__valid",
+            not_issue=["Incorrect information on your report"]
+        )
+
+    def test_search_with_two_not__valid(self):
+        self.request_test(
+            "search_with_two_not__valid",
+            not_issue=["Incorrect information on your report"],
+            not_product=["Credit reporting, credit repair services, or "
+                         "other personal consumer reports"]
         )
 
     def test_search_with_state__valid(self):

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -85,11 +85,14 @@ class EsInterfaceTest_Search(TestCase):
         }
     ]
 
+    DEFAULT_EXCLUDE = ['company', 'zip_code']
+
     # -------------------------------------------------------------------------
     # Helper Methods
     # -------------------------------------------------------------------------
 
-    def request_test(self, expected, **kwargs):
+    def request_test(self, expected, agg_exclude=['company', 'zip_code'],
+                     **kwargs):
         body = load(expected)
 
         with mock.patch(
@@ -110,7 +113,7 @@ class EsInterfaceTest_Search(TestCase):
                 self.MOCK_SEARCH_RESULT["_meta"])
             mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
 
-            res = search(**kwargs)
+            res = search(agg_exclude, **kwargs)
 
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
@@ -248,7 +251,7 @@ class EsInterfaceTest_Search(TestCase):
             self.MOCK_SEARCH_RESULT["_meta"])
         mock_scroll.side_effect = copy.deepcopy(self.MOCK_SCROLL_SIDE_EFFECT)
         body = load("search_with_frm__valid")
-        res = search(frm=20)
+        res = search(self.DEFAULT_EXCLUDE, frm=20)
         self.assertEqual(1, len(mock_search.call_args_list))
         self.assertEqual(2, len(mock_search.call_args_list[0]))
         self.assertEqual(0, len(mock_search.call_args_list[0][0]))
@@ -298,7 +301,7 @@ class EsInterfaceTest_Search(TestCase):
         body = load("search_with_sort__valid")
 
         for s in sort_fields:
-            res = search(sort=s[0])
+            res = search(self.DEFAULT_EXCLUDE, sort=s[0])
             body["sort"] = [{s[1]: {"order": s[2]}}]
             mock_search.assert_any_call(
                 body=body,

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -471,6 +471,20 @@ class SearchTests(APITestCase):
         self.assertEqual('OK', response.data)
 
     @mock.patch('complaint_search.es_interface.search')
+    def test_search_with_not_company__valid(self, mock_essearch):
+        url = reverse('complaint_search:search')
+        url += "?not_company=One%20Bank&not_company=Bank%202"
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        mock_essearch.assert_called_once_with(
+            agg_exclude=AGG_EXCLUDE_FIELDS,
+            **self.buildDefaultParams({
+                "not_company": ["One Bank", "Bank 2"]})
+        )
+        self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
     def test_search_with_product__valid(self, mock_essearch):
         url = reverse('complaint_search:search')
         # parameter doesn't represent real data, as client has a hard time

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -7,6 +7,7 @@ from complaint_search import es_interface
 from complaint_search.decorators import catch_es_error
 from complaint_search.defaults import (
     AGG_EXCLUDE_FIELDS,
+    EXCLUDE_PREFIX,
     EXPORT_FORMATS,
     FORMAT_CONTENT_TYPE_MAP,
 )
@@ -76,6 +77,8 @@ QPARAMS_LISTS = (
     'zip_code'
 )
 
+QPARAMS_NOT_LISTS = [EXCLUDE_PREFIX + x for x in QPARAMS_LISTS]
+
 
 def _parse_query_params(query_params, validVars=None):
     if not validVars:
@@ -86,6 +89,8 @@ def _parse_query_params(query_params, validVars=None):
         if param in validVars:
             data[param] = query_params.get(param)
         elif param in QPARAMS_LISTS:
+            data[param] = query_params.getlist(param)
+        elif param in QPARAMS_NOT_LISTS:
             data[param] = query_params.getlist(param)
         # TODO: else: Error if extra parameters? Or ignore?
 


### PR DESCRIPTION
Adds functionality for the `not_` filters so that users can omit certain results from queries. Example: a filter of `not_company=Company1` will omit all results of "Company1".