### PR TITLE
Cherry Pick the Test Refactor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ exclude_lines =
     if __name__ == .__main__.:
     datetime.now()
     diff.print_full()
+    except ImportError:

--- a/ccdb5_api/settings.py
+++ b/ccdb5_api/settings.py
@@ -57,7 +57,7 @@ MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
 )
 
-if django.VERSION < (2, 0):
+if django.VERSION < (2, 0):  # pragma: no cover
     MIDDLEWARE += (
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     )

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -303,6 +303,7 @@ def document(complaint_id):
 def states_agg(agg_exclude=None, **kwargs):
     params = copy.deepcopy(PARAMS)
     params.update(**kwargs)
+    params.update({'size': 0})
     search_builder = SearchBuilder()
     search_builder.add(**params)
     body = search_builder.build()
@@ -313,9 +314,6 @@ def states_agg(agg_exclude=None, **kwargs):
         _ES_URL, _COMPLAINT_ES_INDEX, _COMPLAINT_DOC_TYPE, body
     )
 
-    # AD, TODO: Do I need to hardcode?
-    body["size"] = 0
-    del body['_source']
     del body['highlight']
     del body['sort']
 

--- a/complaint_search/tests/es_interface_test_helpers.py
+++ b/complaint_search/tests/es_interface_test_helpers.py
@@ -1,0 +1,31 @@
+import json
+import os.path
+
+from deepdiff import DeepDiff
+
+
+# -------------------------------------------------------------------------
+# Helper Methods
+# -------------------------------------------------------------------------
+
+def to_absolute(fileName):
+    # where is this module?
+    thisDir = os.path.dirname(__file__)
+    return os.path.join(thisDir, "expected_results", fileName)
+
+
+def load(shortName):
+    fileName = to_absolute(shortName + '.json')
+    with open(fileName, 'r') as f:
+        return json.load(f)
+
+
+# -------------------------------------------------------------------------
+# Test Helper Methods
+# -------------------------------------------------------------------------
+
+def assertBodyEqual(expected, actual):
+    diff = DeepDiff(expected, actual)
+    if diff:  # pragma: no cover
+        print(json.dumps(json.loads(diff.to_json()), indent=2, sort_keys=True))
+        raise AssertionError('Request bodies do not match')

--- a/complaint_search/tests/expected_results/search_with_size_corrected__valid.json
+++ b/complaint_search/tests/expected_results/search_with_size_corrected__valid.json
@@ -21,7 +21,7 @@
     "timely",
     "zip_code"
   ],
-    "size": 500,
+    "size": 100,
     "query": {
         "query_string": {
             "query": "*",

--- a/complaint_search/tests/expected_results/states_agg__valid.json
+++ b/complaint_search/tests/expected_results/states_agg__valid.json
@@ -1,0 +1,101 @@
+{
+  "_source": [
+            "company",
+            "company_public_response",
+            "company_response",
+            "complaint_id",
+            "complaint_what_happened",
+            "consumer_consent_provided",
+            "consumer_disputed",
+            "date_received",
+            "date_sent_to_company",
+            "has_narrative",
+            "issue",
+            "product",
+            "state",
+            "submitted_via",
+            "sub_issue",
+            "sub_product",
+            "tags",
+            "timely",
+            "zip_code"
+        ],
+  "aggs": {
+    "issue": {
+      "aggs": {
+        "issue": {
+          "terms": {
+            "field": "issue.raw",
+            "size": 5
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "filter": [],
+          "must": [],
+          "should": []
+        }
+      }
+    },
+    "product": {
+      "aggs": {
+        "product": {
+          "terms": {
+            "field": "product.raw",
+            "size": 5
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "filter": [],
+          "must": [],
+          "should": []
+        }
+      }
+    },
+    "state": {
+      "aggs": {
+        "state": {
+          "aggs": {
+            "issue": {
+              "terms": {
+                "field": "issue.raw",
+                "size": 1
+              }
+            },
+            "product": {
+              "terms": {
+                "field": "product.raw",
+                "size": 1
+              }
+            }
+          },
+          "terms": {
+            "field": "state",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "filter": [],
+          "must": [],
+          "should": []
+        }
+      }
+    }
+  },
+  "from": 0,
+  "query": {
+    "query_string": {
+      "default_operator": "AND",
+      "fields": [
+        "complaint_what_happened"
+      ],
+      "query": "*"
+    }
+  },
+  "size": 0
+}

--- a/complaint_search/tests/expected_results/states_date_filters__valid.json
+++ b/complaint_search/tests/expected_results/states_date_filters__valid.json
@@ -1,0 +1,108 @@
+{
+    "_scroll_id": "cXVlcnlUaGVuRmV0Y2g7NTsxNjYxNzpmaUlRdTA0dlJyZTJjVlpROXBoeFBBOzE2NjE4OmZpSVF1MDR2UnJlMmNWWlE5cGh4UEE7MTY2MTY6ZmlJUXUwNHZScmUyY1ZaUTlwaHhQQTsxNjYxOTpmaUlRdTA0dlJyZTJjVlpROXBoeFBBOzE2NjIwOmZpSVF1MDR2UnJlMmNWWlE5cGh4UEE7MDs=",
+    "took": 109,
+    "timed_out": false,
+    "_shards": {
+        "total": 5,
+        "successful": 5,
+        "failed": 0
+    },
+    "hits": {
+        "total": 1609587,
+        "max_score": 0.0,
+        "hits": []
+    },
+    "aggregations": {
+        "product": {
+            "doc_count": 2507,
+            "product": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 247,
+                "buckets": [
+                    {
+                        "key": "Credit reporting, credit repair services, or other personal consumer reports",
+                        "doc_count": 1093
+                    },
+                    {
+                        "key": "Debt collection",
+                        "doc_count": 450
+                    },
+                    {
+                        "key": "Credit card or prepaid card",
+                        "doc_count": 280
+                    },
+                    {
+                        "key": "Mortgage",
+                        "doc_count": 262
+                    },
+                    {
+                        "key": "Checking or savings account",
+                        "doc_count": 175
+                    }
+                ]
+            }
+        },
+        "issue": {
+            "doc_count": 2507,
+            "issue": {
+                "doc_count_error_upper_bound": 20,
+                "sum_other_doc_count": 1094,
+                "buckets": [
+                    {
+                        "key": "Incorrect information on your report",
+                        "doc_count": 694
+                    },
+                    {
+                        "key": "Problem with a credit reporting company's investigation into an existing problem",
+                        "doc_count": 296
+                    },
+                    {
+                        "key": "Attempts to collect debt not owed",
+                        "doc_count": 202
+                    },
+                    {
+                        "key": "Managing an account",
+                        "doc_count": 115
+                    },
+                    {
+                        "key": "Trouble during payment process",
+                        "doc_count": 106
+                    }
+                ]
+            }
+        },
+        "state": {
+            "doc_count": 2507,
+            "state": {
+                "doc_count_error_upper_bound": 0,
+                "sum_other_doc_count": 0,
+                "buckets": [
+                    {
+                        "key": "VA",
+                        "doc_count": 2507,
+                        "product": {
+                            "doc_count_error_upper_bound": 0,
+                            "sum_other_doc_count": 1414,
+                            "buckets": [
+                                {
+                                    "key": "Credit reporting, credit repair services, or other personal consumer reports",
+                                    "doc_count": 1093
+                                }
+                            ]
+                        },
+                        "issue": {
+                            "doc_count_error_upper_bound": 60,
+                            "sum_other_doc_count": 1813,
+                            "buckets": [
+                                {
+                                    "key": "Incorrect information on your report",
+                                    "doc_count": 694
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -12,32 +12,15 @@ from complaint_search.es_interface import (
     document,
     filter_suggest,
     search,
-    states_agg,
     suggest,
 )
 from complaint_search.export import ElasticSearchExporter
-from deepdiff import DeepDiff
+from complaint_search.tests.es_interface_test_helpers import (
+    assertBodyEqual,
+    load,
+)
 from elasticsearch import Elasticsearch
 from nose_parameterized import parameterized
-
-
-# -------------------------------------------------------------------------
-# Helper Methods
-# -------------------------------------------------------------------------
-
-
-def to_absolute(fileName):
-    import os.path
-    # where is this module?
-    thisDir = os.path.dirname(__file__)
-    return os.path.join(thisDir, "expected_results", fileName)
-
-
-def load(shortName):
-    import json
-    fileName = to_absolute(shortName + '.json')
-    with open(fileName, 'r') as f:
-        return json.load(f)
 
 
 class EsInterfaceTest_Search(TestCase):
@@ -102,6 +85,47 @@ class EsInterfaceTest_Search(TestCase):
         }
     ]
 
+    # -------------------------------------------------------------------------
+    # Helper Methods
+    # -------------------------------------------------------------------------
+
+    def request_test(self, expected, **kwargs):
+        body = load(expected)
+
+        with mock.patch(
+            "complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX"
+        ), mock.patch(
+            "complaint_search.es_interface._get_meta"
+        ) as mock_get_meta, mock.patch.object(
+            Elasticsearch, 'search'
+        ) as mock_search, mock.patch.object(
+            Elasticsearch, 'count'
+        ) as mock_count, mock.patch.object(
+            Elasticsearch, 'scroll'
+        ) as mock_scroll:
+            mock_search.side_effect = copy.deepcopy(
+                self.MOCK_SEARCH_SIDE_EFFECT)
+            mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
+            mock_get_meta.return_value = copy.deepcopy(
+                self.MOCK_SEARCH_RESULT["_meta"])
+            mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
+
+            res = search(**kwargs)
+
+        self.assertEqual(1, len(mock_search.call_args_list))
+        self.assertEqual(2, len(mock_search.call_args_list[0]))
+        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
+        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
+
+        assertBodyEqual(body, mock_search.call_args_list[0][1]['body'])
+        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
+        mock_scroll.assert_not_called()
+        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+
+    # -------------------------------------------------------------------------
+    # Tests
+    # -------------------------------------------------------------------------
+
     @mock.patch("complaint_search.es_interface._get_now")
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch.object(Elasticsearch, 'count')
@@ -143,175 +167,16 @@ class EsInterfaceTest_Search(TestCase):
         exp_res['has_data_issue'] = True
         self.assertDictEqual(exp_res, res)
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_no_param__valid(
-        self,
-        mock_rget,
-        mock_scroll,
-        mock_count,
-        mock_search,
-        mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
-        body = load("search_no_param__valid")
-        res = search()
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
+    def test_search_no_param__valid(self, mock_rget):
+        self.request_test("search_no_param__valid")
         mock_rget.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_agg_exclude__valid(
-        self,
-        mock_rget,
-        mock_scroll,
-        mock_count,
-        mock_search,
-        mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
-        body = load("search_agg_exclude__valid")
-        res = search(agg_exclude=['zip_code'])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
+    def test_search_agg_exclude__valid(self, mock_rget):
+        self.request_test("search_agg_exclude__valid",
+                          agg_exclude=['zip_code'])
         mock_rget.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
-
-    # @mock.patch("complaint_search.es_interface._ES_URL", "ES_URL")
-    # @mock.patch("complaint_search.es_interface._ES_USER", "ES_USER")
-    # @mock.patch("complaint_search.es_interface._ES_PASSWORD", "ES_PASSWORD")
-    # @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    # @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
-    # "DOC_TYPE")
-    # @mock.patch.object(Elasticsearch, 'search')
-    # @mock.patch('requests.Session.get')
-    # @mock.patch('json.dumps')
-    # @mock.patch('urllib.urlencode')
-    # def test_search_with_format_json__valid(self, mock_urlencode,
-    #         mock_jdump, mock_rget, mock_search):
-    #     mock_search.return_value = 'OK'
-    #     mock_jdump.return_value = 'JDUMPS_OK'
-    #     RGet = namedtuple('RGet', 'ok, iter_content')
-    #     mock_rget.return_value = RGet(
-    #         ok=True, iter_content=mock.MagicMock(return_value='RGET_OK'))
-    #     body = load("search_with_format_json__valid")
-    #     format = 'json'
-    #     res = search(format=format)
-    #     expected_res = 'RGET_OK'
-    #     self.assertTrue(isinstance(res, StreamJSONContent))
-    #     self.assertEqual(res.content, 'RGET_OK')
-
-    #     self.assertEqual(len(mock_jdump.call_args), 2)
-    #     self.assertEqual(1, len(mock_jdump.call_args[0]))
-    #     act_body = mock_jdump.call_args[0][0]
-    #     diff = deep.diff(act_body, body)
-    #     if diff:
-    #         diff.print_full()
-    #     self.assertIsNone(deep.diff(act_body, body))
-    #     self.assertEqual(len(mock_urlencode.call_args), 2)
-    #     self.assertEqual(1, len(mock_urlencode.call_args[0]))
-    #     param = {
-    #         "format": format,
-    #         "source": "JDUMPS_OK",
-    #         "append.header": "false",
-    #         "fl": ",".join(header for header in CSV_ORDERED_HEADERS.keys())
-    #     }
-    #     act_param = mock_urlencode.call_args[0][0]
-    #     self.assertEqual(param, act_param)
-
-    #     self.assertEqual(mock_jdump.call_count, 1)
-    #     self.assertEqual(mock_urlencode.call_count, 1)
-
-    #     mock_search.assert_not_called()
-    #     self.assertEqual(1, mock_rget.call_count)
-
-    # @mock.patch("complaint_search.es_interface._ES_URL", "ES_URL")
-    # @mock.patch("complaint_search.es_interface._ES_USER", "ES_USER")
-    # @mock.patch("complaint_search.es_interface._ES_PASSWORD", "ES_PASSWORD")
-    # @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    # @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
-    # "DOC_TYPE")
-    # @mock.patch.object(Elasticsearch, 'search')
-    # @mock.patch('requests.Session.get')
-    # @mock.patch('json.dumps')
-    # @mock.patch('urllib.urlencode')
-    # def test_search_with_format_csv__valid(
-    #         self, mock_urlencode, mock_jdump, mock_rget, mock_search):
-    #     mock_search.return_value = 'OK'
-    #     mock_jdump.return_value = 'JDUMPS_OK'
-    #     RGet = namedtuple('RGet', 'ok, iter_content')
-    #     mock_rget.return_value = RGet(
-    #         ok=True, iter_content=mock.MagicMock(return_value='RGET_OK'))
-    #     body = load("search_with_format_csv__valid")
-    #     format = 'csv'
-    #     res = search(format=format)
-    #     expected_res = 'RGET_OK'
-
-    #     expected_header = ",".join('"' + header + '"'
-    #         for header in CSV_ORDERED_HEADERS.values()) + "\n"
-    #     self.assertTrue(isinstance(res, StreamCSVContent))
-    #     self.assertEqual(res.header, expected_header)
-    #     self.assertEqual(res.content, 'RGET_OK')
-
-    #     self.assertEqual(len(mock_jdump.call_args), 2)
-    #     self.assertEqual(1, len(mock_jdump.call_args[0]))
-    #     act_body = mock_jdump.call_args[0][0]
-    #     diff = deep.diff(act_body, body)
-    #     if diff:
-    #         diff.print_full()
-    #     self.assertIsNone(deep.diff(act_body, body))
-    #     self.assertEqual(len(mock_urlencode.call_args), 2)
-    #     self.assertEqual(1, len(mock_urlencode.call_args[0]))
-    #     param = {
-    #         "format": format,
-    #         "source": "JDUMPS_OK",
-    #         "append.header": "false",
-    #         "fl": ",".join(header for header in CSV_ORDERED_HEADERS.keys())
-    #     }
-    #     act_param = mock_urlencode.call_args[0][0]
-    #     self.assertEqual(param, act_param)
-
-    #     self.assertEqual(mock_jdump.call_count, 1)
-    #     self.assertEqual(mock_urlencode.call_count, 1)
-
-    #     mock_search.assert_not_called()
-    #     self.assertEqual(1, mock_rget.call_count)
 
     @parameterized.expand([
         ['csv'],
@@ -348,63 +213,11 @@ class EsInterfaceTest_Search(TestCase):
             self.assertEqual(1, mock_exporter_json.call_count)
             self.assertEqual(0, mock_exporter_csv.call_count)
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_field__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
-        body = load("search_with_field__valid")
-        res = search(field="test_field")
-        # print "MOCK CALL ARGS LIST: "
-        # print json.dumps(mock_search.call_args_list)
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_field__valid(self):
+        self.request_test("search_with_field__valid", field="test_field")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_field_all__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
-        body = load("search_with_field_all__valid")
-        res = search(field="_all")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_field_all__valid(self):
+        self.request_test("search_with_field_all__valid", field="_all")
 
     @mock.patch.object(Elasticsearch, 'search')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
@@ -415,46 +228,11 @@ class EsInterfaceTest_Search(TestCase):
         mock_search.assert_not_called()
         mock_rget.assert_not_called()
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_size__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_size__valid")
-        res = search(size=40)
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_size__valid(self):
+        self.request_test("search_with_size__valid", size=40)
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_size_corrected__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        load("search_with_size_corrected__valid")
-        search(size=500)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        self.assertEqual(100, mock_search.call_args_list[0][1]['body']['size'])
-        mock_scroll.assert_not_called()
+    def test_search_with_size_corrected__valid(self):
+        self.request_test("search_with_size_corrected__valid", size=500)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
     @mock.patch("complaint_search.es_interface._get_meta")
@@ -533,684 +311,120 @@ class EsInterfaceTest_Search(TestCase):
         mock_scroll.assert_not_called()
         self.assertEqual(4, mock_search.call_count)
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_match__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_search_term_match__valid")
-        res = search(search_term="test term")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_search_term_match__valid(self):
+        self.request_test("search_with_search_term_match__valid",
+                          search_term="test term")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_and__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_search_term_qsq_and__valid")
-        res = search(search_term="test AND term")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_search_term_qsq_and__valid(self):
+        self.request_test("search_with_search_term_qsq_and__valid",
+                          search_term="test AND term")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_or__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_search_term_qsq_or__valid")
-        res = search(search_term="test OR term")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_search_term_qsq_or__valid(self):
+        self.request_test("search_with_search_term_qsq_or__valid",
+                          search_term="test OR term")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_not__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_search_term_qsq_not__valid")
-        res = search(search_term="test NOT term")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_search_term_qsq_not__valid(self):
+        self.request_test("search_with_search_term_qsq_not__valid",
+                          search_term="test NOT term")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_search_term_qsq_to__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_search_term_qsq_to__valid")
-        res = search(search_term="term TO test")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_search_term_qsq_to__valid(self):
+        self.request_test("search_with_search_term_qsq_to__valid",
+                          search_term="term TO test")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_date_received_min__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_date_received_min__valid")
-        res = search(date_received_min="2014-04-14")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_date_received_min__valid(self):
+        self.request_test("search_with_date_received_min__valid",
+                          date_received_min="2014-04-14")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_date_received_max__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_date_received_max__valid")
-        res = search(date_received_max="2017-04-14")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_date_received_max__valid(self):
+        self.request_test("search_with_date_received_max__valid",
+                          date_received_max="2017-04-14")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_received_min__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_company_received_min__valid")
-        res = search(company_received_min="2014-04-14")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_company_received_min__valid(self):
+        self.request_test("search_with_company_received_min__valid",
+                          company_received_min="2014-04-14")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_received_max__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_company_received_max__valid")
-        res = search(company_received_max="2017-04-14")
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_company_received_max__valid(self):
+        self.request_test("search_with_company_received_max__valid",
+                          company_received_max="2017-04-14")
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_company__valid")
-        res = search(company=["Bank 1", "Second Bank"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_company__valid(self):
+        self.request_test("search_with_company__valid",
+                          company=["Bank 1", "Second Bank"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_agg_exclude__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_company_agg_exclude__valid")
-        res = search(agg_exclude=['company'], company=[
-                     "Bank 1", "Second Bank"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_company_agg_exclude__valid(self):
+        self.request_test("search_with_company_agg_exclude__valid",
+                          agg_exclude=['company'],
+                          company=["Bank 1", "Second Bank"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_product__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_product__valid")
-        res = search([u"zip_code", u"company"],
-                     product=["Payday loan", u"Mortgage\u2022FHA mortgage"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_product__valid(self):
+        self.request_test(
+            "search_with_product__valid",
+            agg_exclude=[u"zip_code", u"company"],
+            product=["Payday loan", u"Mortgage\u2022FHA mortgage"]
+        )
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_issue__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_issue__valid")
-        res = search(
-            [u"zip_code", u"company"],
+    def test_search_with_issue__valid(self):
+        self.request_test(
+            "search_with_issue__valid",
+            agg_exclude=[u"zip_code", u"company"],
             issue=[u"Communication tactics\u2022Frequent or repeated calls",
                    "Loan servicing, payments, escrow account"]
         )
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_state__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_state__valid")
-        res = search(state=["CA", "VA", "OR"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_state__valid(self):
+        self.request_test("search_with_state__valid", state=["CA", "VA", "OR"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_zip_code__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_zip_code__valid")
-        res = search(zip_code=["12345", "23435", "03433"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_zip_code__valid(self):
+        self.request_test("search_with_zip_code__valid",
+                          zip_code=["12345", "23435", "03433"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_zip_code_agg_exclude__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_zip_code_agg_exclude__valid")
-        res = search(agg_exclude=['zip_code'], zip_code=[
-                     "12345", "23435", "03433"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        # print(act_body)
-        # print(body)
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_zip_code_agg_exclude__valid(self):
+        self.request_test(
+            "search_with_zip_code_agg_exclude__valid",
+            agg_exclude=['zip_code'],
+            zip_code=["12345", "23435", "03433"]
+        )
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_timely__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_timely__valid")
-        res = search(timely=["Yes", "No"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_timely__valid(self):
+        self.request_test("search_with_timely__valid", timely=["Yes", "No"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_response__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_company_response__valid")
-        res = search(company_response=[
-                     "Closed", "Closed with non-monetary relief"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_company_response__valid(self):
+        self.request_test(
+            "search_with_company_response__valid",
+            company_response=["Closed", "Closed with non-monetary relief"]
+        )
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_company_public_response__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_company_public_response__valid")
-        res = search(company_public_response=[
-            "Company chooses not to provide a public response",
-            "Company believes it acted appropriately as authorized by "
-            "contract or law"
-        ])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_company_public_response__valid(self):
+        self.request_test(
+            "search_with_company_public_response__valid",
+            company_public_response=[
+                "Company chooses not to provide a public response",
+                "Company believes it acted appropriately as authorized by "
+                "contract or law"
+            ])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_consumer_consent_provided__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_consumer_consent_provided__valid")
-        res = search(consumer_consent_provided=["Consent provided"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_consumer_consent_provided__valid(self):
+        self.request_test(
+            "search_with_consumer_consent_provided__valid",
+            consumer_consent_provided=["Consent provided"]
+        )
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_submitted_via__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_submitted_via__valid")
-        res = search(submitted_via=["Web"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_submitted_via__valid(self):
+        self.request_test("search_with_submitted_via__valid",
+                          submitted_via=["Web"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_tags__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_tags__valid")
-        res = search(tags=["Older American", "Servicemember"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     print(diff)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_tags__valid(self):
+        self.request_test("search_with_tags__valid",
+                          tags=["Older American", "Servicemember"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
-    def test_search_with_has_narrative__valid(
-        self, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        body = load("search_with_has_narrative__valid")
-        res = search(has_narrative=["true"])
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        act_body = mock_search.call_args_list[0][1]['body']
-        diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertEqual(diff, {})
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
-        self.assertEqual(self.MOCK_SEARCH_RESULT, res)
+    def test_search_with_has_narrative__valid(self):
+        self.request_test("search_with_has_narrative__valid",
+                          has_narrative=["true"])
 
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._get_meta")
-    @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch.object(Elasticsearch, 'count')
-    @mock.patch.object(Elasticsearch, 'scroll')
     @mock.patch('requests.get', ok=True, content="RGET_OK")
-    def test_search_no_highlight__valid(
-        self, mock_rget, mock_scroll, mock_count, mock_search, mock_get_meta
-    ):
-        mock_search.side_effect = copy.deepcopy(self.MOCK_SEARCH_SIDE_EFFECT)
-        mock_count.return_value = self.MOCK_COUNT_RETURN_VALUE
-        mock_get_meta.return_value = copy.deepcopy(
-            self.MOCK_SEARCH_RESULT["_meta"])
-        mock_scroll.return_value = self.MOCK_SEARCH_SIDE_EFFECT[0]
-        body = load("search_no_highlight__valid")
-        res = search(no_highlight=True)
-        self.assertEqual(1, len(mock_search.call_args_list))
-        self.assertEqual(2, len(mock_search.call_args_list[0]))
-        self.assertEqual(0, len(mock_search.call_args_list[0][0]))
-        self.assertEqual(4, len(mock_search.call_args_list[0][1]))
-        # act_body = mock_search.call_args_list[0][1]['body']
-        # diff = DeepDiff(act_body, body)
-        # if diff:
-        #     pprint(diff, indent=2)
-        self.assertDictEqual(mock_search.call_args_list[0][1]['body'], body)
-        self.assertEqual(mock_search.call_args_list[0][1]['index'], 'INDEX')
-        mock_scroll.assert_not_called()
+    def test_search_no_highlight__valid(self, mock_rget):
+        self.request_test("search_no_highlight__valid", no_highlight=True)
         mock_rget.assert_not_called()
-        self.assertDictEqual(self.MOCK_SEARCH_RESULT, res)
 
 
 class EsInterfaceTest_Suggest(TestCase):
@@ -1473,23 +687,6 @@ class EsInterfaceTest_Document(TestCase):
         self.assertEqual(0, len(mock_search.call_args[0]))
         self.assertEqual(3, len(mock_search.call_args[1]))
         self.assertDictEqual(mock_search.call_args[1]['body'], body)
-        self.assertEqual(mock_search.call_args[1]['doc_type'], 'DOC_TYPE')
-        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
-        self.assertEqual('OK', res)
-
-
-class EsInterfaceTest_States(TestCase):
-
-    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
-                "DOC_TYPE")
-    @mock.patch.object(Elasticsearch, 'search')
-    def test_states__valid(self, mock_search):
-        mock_search.return_value = 'OK'
-        res = states_agg()
-        self.assertEqual(len(mock_search.call_args), 2)
-        self.assertEqual(0, len(mock_search.call_args[0]))
-        self.assertEqual(4, len(mock_search.call_args[1]))
         self.assertEqual(mock_search.call_args[1]['doc_type'], 'DOC_TYPE')
         self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
         self.assertEqual('OK', res)

--- a/complaint_search/tests/test_es_interface_states.py
+++ b/complaint_search/tests/test_es_interface_states.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+
+import mock
+from complaint_search.es_interface import states_agg
+from complaint_search.tests.es_interface_test_helpers import (
+    assertBodyEqual,
+    load,
+)
+from elasticsearch import Elasticsearch
+
+
+class EsInterfaceTest_States(TestCase):
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
+                "DOC_TYPE")
+    @mock.patch.object(Elasticsearch, 'search')
+    def test_states__valid(self, mock_search):
+        body = load('states_agg__valid')
+
+        mock_search.return_value = 'OK'
+        res = states_agg()
+        self.assertEqual(len(mock_search.call_args), 2)
+        self.assertEqual(0, len(mock_search.call_args[0]))
+        self.assertEqual(4, len(mock_search.call_args[1]))
+        self.assertEqual(mock_search.call_args[1]['doc_type'], 'DOC_TYPE')
+        assertBodyEqual(body, mock_search.call_args_list[0][1]['body'])
+        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
+        self.assertEqual('OK', res)
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
+                "DOC_TYPE")
+    @mock.patch.object(Elasticsearch, 'search')
+    def test_states_exclude__valid(self, mock_search):
+        body = load('states_agg__valid')
+
+        mock_search.return_value = 'OK'
+        res = states_agg(['zip_code'])
+        self.assertEqual(len(mock_search.call_args), 2)
+        self.assertEqual(0, len(mock_search.call_args[0]))
+        self.assertEqual(4, len(mock_search.call_args[1]))
+        self.assertEqual(mock_search.call_args[1]['doc_type'], 'DOC_TYPE')
+        assertBodyEqual(body, mock_search.call_args_list[0][1]['body'])
+        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
+        self.assertEqual('OK', res)
+
+    @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
+    @mock.patch("complaint_search.es_interface._COMPLAINT_DOC_TYPE",
+                "DOC_TYPE")
+    @mock.patch.object(Elasticsearch, 'search')
+    def test_states_date_filters__valid(self, mock_search):
+        params = {
+            'date_received_min': '01-01-2020',
+            'date_received_max': '05-05-2020',
+            'company_received_min': '01-01-2020',
+            'company_received_max': '05-05-2020',
+            'state': 'VA',
+            'size': 0
+        }
+
+        expected = load('states_date_filters__valid')
+
+        mock_search.return_value = expected
+        res = states_agg(**params)
+        self.assertEqual(len(mock_search.call_args), 2)
+        self.assertEqual(0, len(mock_search.call_args[0]))
+        self.assertEqual(4, len(mock_search.call_args[1]))
+        self.assertEqual(mock_search.call_args[1]['doc_type'], 'DOC_TYPE')
+        self.assertEqual(mock_search.call_args[1]['index'], 'INDEX')
+        self.assertDictEqual(res, expected)


### PR DESCRIPTION
In my `event_tag` branch and in `dev`, the tests have been refactored so that the coverage shows 100%.  It would be nice to have that in `master` especially with some hotfixes upcoming

These commits were `cherry-pick`ed from `dev`

* 58e81cb
* 30d3483
* 268f7b6