### PR TITLE
Switch suggesters to "contains" rather than "starts with"

### DIFF
--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -611,8 +611,8 @@ class EsInterfaceTest_FilterSuggest(TestCase):
                             'bool': {
                                 'must': [
                                     {
-                                        'prefix': {
-                                            'company.suggest': 'BA'
+                                        'wildcard': {
+                                            'company.suggest': '*BA*'
                                         }}]}
                         },
                         "aggs": {

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def format_version(version, fmt=fmt):
 
     # Sometimes the closest tag has '-dev' and messes everything up
     if len(parts) == 5 and parts[1] == 'dev':
-        parts = [parts[0]] + parts[1:3]
+        parts = [parts[0] + '-dev', parts[2], parts[3], parts[4]]
 
     assert len(parts) in (3, 4), '|'.join(parts)
     dirty = len(parts) == 4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ def format_version(version, fmt=fmt):
     if len(parts) == 1:
         return fmt.format(tag='ci', commitcount=0, gitsha=version)
 
-    assert len(parts) in (3, 4)
+    # Sometimes the closest tag has '-dev' and messes everything up
+    if len(parts) == 5 and parts[1] == 'dev':
+        parts = [parts[0]] + parts[1:3]
+
+    assert len(parts) in (3, 4), '|'.join(parts)
     dirty = len(parts) == 4
     tag, count, sha = parts[:3]
     if count == '0' and not dirty:

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands=
 basepython=python3.6
 deps=
     flake8
-    isort
+    isort == 4.3.21
 commands=
     flake8 ccdb5_api complaint_search
     isort --check-only --diff --recursive ccdb5_api complaint_search


### PR DESCRIPTION
Currently, the company type-ahead only picks up the first letter/words. If users type partial word that happens to be in the middle of the name, the type-ahead doesn't pick up. For example, trying to search for 'Chase', will find 0 results since the company name is 'JP Morgan Chase'

This PR uses `wildcard` instead of `prefix` to search:

- `issue` (will find "Mortgage" in "Closing on a mortgage")
- `state` (will find "Jersey" in "New Jersey")
- `company` (satisfies the use case)

The code will still use `prefix` for zip codes since there are a lot of zip codes and they are rarely searched for in the middle. ('210' would not expect to return '90210')