### PR TITLE
Narrative bugfix

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -60,9 +60,6 @@ class BaseBuilder(object):
         "zip_code",
     )
 
-    # Filters for those that need conversion from string to boolean
-    _OPTIONAL_FILTERS_STRING_TO_BOOL = ("has_narrative",)
-
     # Filters that use different names in Elasticsearch
     _OPTIONAL_FILTERS_PARAM_TO_ES_MAP = {
         "company_public_response": "company_public_response.raw",

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -50,6 +50,7 @@ class BaseBuilder(object):
         "company_response",
         "consumer_consent_provided",
         "consumer_disputed",
+        "has_narrative",
         "issue",
         "product",
         "state",

--- a/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
+++ b/complaint_search/tests/expected_results/search_with_has_narrative__valid.json
@@ -1,249 +1,337 @@
 {
-  "from": 0,
-  "size": 10,
-  "_source": [
-    "company",
-    "company_public_response",
-    "company_response",
-    "complaint_id",
-    "complaint_what_happened",
-    "consumer_consent_provided",
-    "consumer_disputed",
-    "date_received",
-    "date_sent_to_company",
-    "has_narrative",
-    "issue",
-    "product",
-    "state",
-    "submitted_via",
-    "sub_issue",
-    "sub_product",
-    "tags",
-    "timely",
-    "zip_code"
-  ],
-  "query": {
-    "query_string": {
-      "query": "*",
-      "fields": [
-        "complaint_what_happened"
-      ],
-      "default_operator": "AND"
-    }
-  },
-  "highlight": {
-    "require_field_match": false,
-    "number_of_fragments": 1,
-    "fragment_size": 500,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "sort": [
-    {
-      "_score": {
-        "order": "desc"
+    "from": 0,
+    "size": 10,
+    "_source": [
+      "company",
+      "company_public_response",
+      "company_response",
+      "complaint_id",
+      "complaint_what_happened",
+      "consumer_consent_provided",
+      "consumer_disputed",
+      "date_received",
+      "date_sent_to_company",
+      "has_narrative",
+      "issue",
+      "product",
+      "state",
+      "submitted_via",
+      "sub_issue",
+      "sub_product",
+      "tags",
+      "timely",
+      "zip_code"
+    ],
+    "query": {
+      "query_string": {
+        "query": "*",
+        "fields": [
+          "complaint_what_happened"
+        ],
+        "default_operator": "AND"
       }
-    }
-  ],
-  "post_filter": {
-    "bool": {
-      "must": [],
-      "must_not": []
-    }
-  },
-  "aggs": {
-    "company_public_response": {
-      "aggs": {
-        "company_public_response": {
-          "terms": {
-            "field": "company_public_response.raw",
-            "size": 0
+    },
+    "highlight": {
+      "require_field_match": false,
+      "number_of_fragments": 1,
+      "fragment_size": 500,
+      "fields": {
+        "complaint_what_happened": {}
+      }
+    },
+    "sort": [
+      {
+        "_score": {
+          "order": "desc"
+        }
+      }
+    ],
+    "post_filter": {
+      "bool": {
+        "must": [
+          {
+            "terms": {
+              "has_narrative": [
+                "true"
+              ]
+            }
+          }
+        ],
+        "must_not": []
+      }
+    },
+    "aggs": {
+      "company_public_response": {
+        "aggs": {
+          "company_public_response": {
+            "terms": {
+              "field": "company_public_response.raw",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "company_response": {
-      "aggs": {
-        "company_response": {
-          "terms": {
-            "field": "company_response",
-            "size": 0
+      "company_response": {
+        "aggs": {
+          "company_response": {
+            "terms": {
+              "field": "company_response",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "consumer_consent_provided": {
-      "aggs": {
-        "consumer_consent_provided": {
-          "terms": {
-            "field": "consumer_consent_provided.raw",
-            "size": 0
+      "consumer_consent_provided": {
+        "aggs": {
+          "consumer_consent_provided": {
+            "terms": {
+              "field": "consumer_consent_provided.raw",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "consumer_disputed": {
-      "aggs": {
-        "consumer_disputed": {
-          "terms": {
-            "field": "consumer_disputed.raw",
-            "size": 0
+      "consumer_disputed": {
+        "aggs": {
+          "consumer_disputed": {
+            "terms": {
+              "field": "consumer_disputed.raw",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "has_narrative": {
-      "aggs": {
-        "has_narrative": {
-          "terms": {
-            "field": "has_narrative",
-            "size": 0
+      "has_narrative": {
+        "aggs": {
+          "has_narrative": {
+            "terms": {
+              "field": "has_narrative",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "issue": {
-      "aggs": {
-        "issue": {
-          "terms": {
-            "field": "issue.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_issue.raw": {
-              "terms": {
-                "field": "sub_issue.raw",
-                "size": 0
+      "issue": {
+        "aggs": {
+          "issue": {
+            "terms": {
+              "field": "issue.raw",
+              "size": 0
+            },
+            "aggs": {
+              "sub_issue.raw": {
+                "terms": {
+                  "field": "sub_issue.raw",
+                  "size": 0
+                }
               }
             }
           }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
+          }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "product": {
-      "aggs": {
-        "product": {
-          "terms": {
-            "field": "product.raw",
-            "size": 0
-          },
-          "aggs": {
-            "sub_product.raw": {
-              "terms": {
-                "field": "sub_product.raw",
-                "size": 0
+      "product": {
+        "aggs": {
+          "product": {
+            "terms": {
+              "field": "product.raw",
+              "size": 0
+            },
+            "aggs": {
+              "sub_product.raw": {
+                "terms": {
+                  "field": "sub_product.raw",
+                  "size": 0
+                }
               }
             }
           }
-        }
-      },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "state": {
-      "aggs": {
-        "state": {
-          "terms": {
-            "field": "state",
-            "size": 0
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "submitted_via": {
-      "aggs": {
-        "submitted_via": {
-          "terms": {
-            "field": "submitted_via",
-            "size": 0
+      "state": {
+        "aggs": {
+          "state": {
+            "terms": {
+              "field": "state",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "tags": {
-      "aggs": {
-        "tags": {
-          "terms": {
-            "field": "tags",
-            "size": 0
+      "submitted_via": {
+        "aggs": {
+          "submitted_via": {
+            "terms": {
+              "field": "submitted_via",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
-        }
-      }
-    },
-    "timely": {
-      "aggs": {
-        "timely": {
-          "terms": {
-            "field": "timely",
-            "size": 0
+      "tags": {
+        "aggs": {
+          "tags": {
+            "terms": {
+              "field": "tags",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
           }
         }
       },
-      "filter": {
-        "bool": {
-          "must": [],
-          "must_not": []
+      "timely": {
+        "aggs": {
+          "timely": {
+            "terms": {
+              "field": "timely",
+              "size": 0
+            }
+          }
+        },
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "terms": {
+                  "has_narrative": [
+                    "true"
+                  ]
+                }
+              }
+            ],
+            "must_not": []
+          }
         }
       }
     }
   }
-}


### PR DESCRIPTION
The `has_narrative` parameter got left out of aggregation filters when the filtering was refactored (due to `has_narrative` having some special logic for converting strings to bools). This PR adds back `has_narrative` as a filter option for aggregations.