### PR TITLE
Include aggregation if it is used as a filter

### DIFF
--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -409,8 +409,10 @@ class AggregationBuilder(BaseBuilder):
 
         agg_fields = self._AGG_FIELDS
         if self.exclude:
-            agg_fields = [field_name for field_name in self._AGG_FIELDS
-                          if field_name not in self.exclude]
+            agg_fields = [
+                field_name for field_name in self._AGG_FIELDS
+                if field_name not in self.exclude or field_name in self.params
+            ]
         for field_name in agg_fields:
             aggs[field_name] = self.build_one(field_name)
 

--- a/complaint_search/tests/expected_results/search_with_company__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company__valid.json
@@ -62,6 +62,22 @@
     }
   },
   "aggs": {
+    "company": {
+      "aggs": {
+        "company": {
+          "terms": {
+            "field": "company.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
     "company_public_response": {
       "aggs": {
         "company_public_response": {

--- a/complaint_search/tests/expected_results/search_with_company_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_with_company_agg_exclude__valid.json
@@ -62,6 +62,22 @@
     }
   },
   "aggs": {
+    "company": {
+      "aggs": {
+        "company": {
+          "terms": {
+            "field": "company.raw",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
+    },
     "company_public_response": {
       "aggs": {
         "company_public_response": {

--- a/complaint_search/tests/expected_results/search_with_zip_code__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code__valid.json
@@ -364,6 +364,22 @@
           "must_not": []
         }
       }
+    },
+    "zip_code": {
+      "aggs": {
+        "zip_code": {
+          "terms": {
+            "field": "zip_code",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
     }
   }
 }

--- a/complaint_search/tests/expected_results/search_with_zip_code_agg_exclude__valid.json
+++ b/complaint_search/tests/expected_results/search_with_zip_code_agg_exclude__valid.json
@@ -390,6 +390,22 @@
           "must_not": []
         }
       }
+    },
+    "zip_code": {
+      "aggs": {
+        "zip_code": {
+          "terms": {
+            "field": "zip_code",
+            "size": 0
+          }
+        }
+      },
+      "filter": {
+        "bool": {
+          "must": [],
+          "must_not": []
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Currently, when a user adds a Company or ZIP Code, it is not staying in the left-hand filter.

Acceptance Criteria:

* Any filter added by a user should stay checked on the left-hand side under the appropriate filter heading.

## Screenshots

![tricksy-aggs](https://user-images.githubusercontent.com/8754176/87581035-53bd3100-c6a6-11ea-91c8-c117c90b0921.gif)
