### PR TITLE
Updating interval params in API docs

### DIFF
--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -528,7 +528,7 @@ components:
     trend_interval:
       name: trend_interval
       in: query
-      description: The interval of time to use for trends aggregations histograms.
+      description: The interval of time to use for trends aggregations histograms. When using day intervals, we recommend querying for date_received_min / max periods of less than one year.
       required: true
       schema:
         type: string

--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -533,11 +533,11 @@ components:
       schema:
         type: string
         enum:
-          - yearly
-          - quarterly
-          - monthly
-          - weekly
-          - daily
+          - year
+          - quarter
+          - month
+          - week
+          - day
     zip_code:
       name: zip_code
       in: query


### PR DESCRIPTION
- Removing the `ly` suffix not used in `trend_interval` parameters.
- Added suggested filter parameters for `day` interval parameter to description