### PR TITLE
Support LTS + Current versions of Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/cfpb/ccdb5-api.svg?branch=master)](https://travis-ci.org/cfpb/ccdb5-api)[![Coverage Status](https://coveralls.io/repos/github/cfpb/ccdb5-api/badge.svg?branch=master)](https://coveralls.io/github/cfpb/ccdb5-api?branch=master)
+[![Build Status](https://travis-ci.org/cfpb/ccdb5-api.svg?branch=main)](https://travis-ci.org/cfpb/ccdb5-api)[![Coverage Status](https://coveralls.io/repos/github/cfpb/ccdb5-api/badge.svg?branch=main)](https://coveralls.io/github/cfpb/ccdb5-api?branch=main)
 
 ccdb5-api
 ================

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/cfpb/ccdb5-api.svg?branch=main)](https://travis-ci.org/cfpb/ccdb5-api)[![Coverage Status](https://coveralls.io/repos/github/cfpb/ccdb5-api/badge.svg?branch=main)](https://coveralls.io/github/cfpb/ccdb5-api?branch=main)
-=======
+![ci](https://github.com/cfpb/ccdb5-api/workflows/ci/badge.svg)[![Coverage Status](https://coveralls.io/repos/github/cfpb/ccdb5-api/badge.svg?branch=main)](https://coveralls.io/github/cfpb/ccdb5-api?branch=main)
 
 ccdb5-api
 ================

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,13 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 
 install_requires = [
-    'Django>=1.11,<2.3',
+    'Django>=1.11,<3.2',
     'djangorestframework>=3.9.1,<4.0',
     'django-rest-swagger>=2.2.0',
     'requests>=2.18,<3',
     'elasticsearch>=2.4.1,<3',
     'django-localflavor>=1.1,<3.1',
-    'django-flags>=4.0.1,<5',
+    'django-flags>=4.0.1,<5.1',
 ]
 
 testing_extras = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36}-dj{111,22}
+envlist=lint,py{36}-dj{111,22,31}
 
 [testenv]
 basepython=
@@ -8,6 +8,8 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj22: Django>=2.2,<2.3
+    dj31: Django>=3.1,>3.2
+
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 setenv=
     DJANGO_SETTINGS_MODULE=ccdb5_api.tox

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ basepython=
 deps=
     dj111: Django>=1.11,<1.12
     dj22: Django>=2.2,<2.3
-    dj31: Django>=3.1,>3.2
+    dj31: Django>=3.1,<3.2
 
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 setenv=


### PR DESCRIPTION
This change updates our supported version range to the LTS release of Django (2.2) and the current release of Django (3.1).

## Additions

- Added support for Django 3.1

## Testing

- tox