### PR TITLE
Sidestep API throttling when in DEBUG mode

### DIFF
--- a/complaint_search/throttling.py
+++ b/complaint_search/throttling.py
@@ -1,5 +1,7 @@
 import os
 
+from django.conf import settings
+
 from rest_framework.throttling import AnonRateThrottle
 
 from complaint_search.defaults import EXPORT_FORMATS
@@ -27,6 +29,8 @@ class CCDBAnonRateThrottle(CCDBRateThrottle):
     scope = 'ccdb_anon'
 
     def allow_request(self, request, view):
+        if settings.DEBUG is True:
+            return True
         if not self.is_referred_from_ui(request, view):
             return super(CCDBAnonRateThrottle, self).allow_request(
                 request, view


### PR DESCRIPTION
Integration testing with Cypress is difficult when testing on a server, because many of the
test actions generate API calls that violate throttling rules, and the tests have to be
slowed down to work.

This change allows throttling to be sidestepped when DEBUG is True, which can be set
locally and on servers where CI testing could be run.

DEBUG Is always False in production, but we don't want to be doing Cypress testing there.