### PR TITLE
Remove unneeded hits from map-tab requests

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -440,7 +440,7 @@ def document(complaint_id):
 def states_agg(agg_exclude=None, **kwargs):
     params = copy.deepcopy(PARAMS)
     params.update(**kwargs)
-    params.update({'size': 500})
+    params.update({'size': 0})
     search_builder = SearchBuilder()
     search_builder.add(**params)
     body = search_builder.build()

--- a/complaint_search/tests/expected_results/states_agg__valid.json
+++ b/complaint_search/tests/expected_results/states_agg__valid.json
@@ -1,5 +1,5 @@
 {
-  "size": 500,
+  "size": 0,
   "track_total_hits": true,
   "_source": [
     "company",
@@ -21,18 +21,6 @@
     "tags",
     "timely",
     "zip_code"
-  ],
-  "highlight": {
-    "require_field_match": false,
-    "number_of_fragments": 1,
-    "fragment_size": 500,
-    "fields": {
-      "complaint_what_happened": {}
-    }
-  },
-  "sort": [
-    {"_score": {"order": "desc"}},
-    {"_id": "desc"}
   ],
   "aggs": {
     "issue": {

--- a/complaint_search/tests/expected_results/states_date_filters__valid.json
+++ b/complaint_search/tests/expected_results/states_date_filters__valid.json
@@ -1,5 +1,5 @@
 {
-    "size": 500,
+    "size": 0,
     "track_total_hits": true,
     "_source": [
         "company",
@@ -21,18 +21,6 @@
         "tags",
         "timely",
         "zip_code"
-    ],
-    "highlight": {
-        "require_field_match": false,
-        "number_of_fragments": 1,
-        "fragment_size": 500,
-        "fields": {
-            "complaint_what_happened": {}
-        }
-    },
-    "sort": [
-      {"_score": {"order": "desc"}},
-      {"_id": "desc"}
     ],
     "aggs": {
         "issue": {


### PR DESCRIPTION
A test `size` value was errantly left in the es_interface.states_agg function.
The map tab does not need any hits, so size should be 0 for efficiency.