### PR TITLE
Convert custom elasticsearch7 imports to elasticsearch

### DIFF
--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -1,6 +1,6 @@
 import logging
 
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.response import Response
 

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime, timedelta
 
-from elasticsearch7 import Elasticsearch, RequestsHttpConnection, helpers
+from elasticsearch import Elasticsearch, RequestsHttpConnection, helpers
 from flags.state import flag_enabled
 from requests_aws4auth import AWS4Auth
 

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -5,7 +5,7 @@ from django.http import StreamingHttpResponse
 from django.test import SimpleTestCase, TestCase
 
 import mock
-from elasticsearch7 import Elasticsearch
+from elasticsearch import Elasticsearch
 from parameterized import parameterized
 
 from complaint_search.es_builders import AggregationBuilder, SearchBuilder
@@ -327,7 +327,7 @@ class EsInterfaceTest_Search(TestCase):
     @mock.patch.object(ElasticSearchExporter, 'export_csv')
     @mock.patch.object(ElasticSearchExporter, 'export_json')
     @mock.patch.object(Elasticsearch, 'search')
-    @mock.patch('elasticsearch7.helpers.scan')
+    @mock.patch('elasticsearch.helpers.scan')
     def test_search_with_format__valid(
         self,
         export_type,

--- a/complaint_search/tests/test_es_interface_states.py
+++ b/complaint_search/tests/test_es_interface_states.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 import mock
-from elasticsearch7 import Elasticsearch
+from elasticsearch import Elasticsearch
 
 from complaint_search.es_interface import states_agg
 from complaint_search.tests.es_interface_test_helpers import (

--- a/complaint_search/tests/test_es_interface_trends.py
+++ b/complaint_search/tests/test_es_interface_trends.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 import mock
-from elasticsearch7 import Elasticsearch
+from elasticsearch import Elasticsearch
 
 from complaint_search.es_interface import trends
 from complaint_search.tests.es_interface_test_helpers import load

--- a/complaint_search/tests/test_view_suggest_company.py
+++ b/complaint_search/tests/test_view_suggest_company.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.urls import reverse
 
 import mock
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.test import override_settings
 
 import mock
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -7,7 +7,7 @@ from django.http import StreamingHttpResponse
 from django.test import override_settings
 
 import mock
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase

--- a/complaint_search/tests/test_views_suggest.py
+++ b/complaint_search/tests/test_views_suggest.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 import mock
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/complaint_search/tests/test_views_suggest_company.py
+++ b/complaint_search/tests/test_views_suggest_company.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 import mock
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/complaint_search/tests/test_views_suggest_zip.py
+++ b/complaint_search/tests/test_views_suggest_zip.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 import mock
-from elasticsearch7 import TransportError
+from elasticsearch import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     'djangorestframework>=3.9.1,<4.0',
     'django-rest-swagger>=2.2.0',
     'requests>=2.18,<3',
-    'elasticsearch7>=7.0.0,<8.0.0',
+    'elasticsearch>=7.0.0,<7.11',
     'django-localflavor>=1.1,<3.1',
     'django-flags>=4.0.1,<5.1',
     'requests-aws4auth'


### PR DESCRIPTION
Now that consumerfinance.gov is done with the elasticsearch7 custom package,
we can import `elasticsearch` everywhere, and we'll all be on the latest
version that works with our AWS Elasticsearch services – 7.10.1.

This will not change the version of the package we're using. It only drops the custom build of that version, 
which had allowed us to run ES2 and ES7 side-by-side.