### PR TITLE
Update the Swagger docs to reflect change to hits.total

### DIFF
--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -680,8 +680,14 @@ components:
           description: The highest score in the results
           format: float
         total:
-          type: integer
-          description: The totol number of complaints that matched the query
+          type: object
+            parameters:
+              value:
+                type: integer
+                description: "The count of matching hits, accurate in our code even above 10,000 hits"
+              relation:
+                type: string
+                description: "Indicates the accuracy of the default ES response, whether the value is accurate (eq) or a lower bound (gte)"
     Meta:
       type: object
       properties:


### PR DESCRIPTION
Our Elasticsearch 7 upgrade changed our API to match the ES API, but we didn't
update the Swagger docs, in particular the change in what is returned for hits.total.

Resolves issue #179