### PR TITLE
Fix an indentation-too-far in Swagger config

### DIFF
--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -681,13 +681,13 @@ components:
           format: float
         total:
           type: object
-            parameters:
-              value:
-                type: integer
-                description: "The count of matching hits, accurate in our code even above 10,000 hits"
-              relation:
-                type: string
-                description: "Indicates the accuracy of the default ES response, whether the value is accurate (eq) or a lower bound (gte)"
+          properties:
+            value:
+              type: integer
+              description: "The count of matching hits, accurate in our code even above 10,000 hits"
+            relation:
+              type: string
+              description: "Indicates the accuracy of the default ES response, whether the value is accurate (eq) or a lower bound (gte)"
     Meta:
       type: object
       properties:


### PR DESCRIPTION
TODO: Stop trying to be fast.