### PR TITLE
Remove last bit of ES7 conversion references

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -23,24 +23,20 @@ from complaint_search.es_builders import (
 )
 from complaint_search.export import ElasticSearchExporter
 
-
 log = logging.getLogger(__name__)
 
 _ES_URL = "{}://{}:{}".format("http", os.environ.get('ES_HOST', 'localhost'),
                               os.environ.get('ES_PORT', '9200'))
 _ES_USER = os.environ.get('ES_USER', '')
 _ES_PASSWORD = os.environ.get('ES_PASSWORD', '')
-
 _ES_INSTANCE = None
 
 USE_AWS_ES = os.environ.get('USE_AWS_ES', False)
 AWS_ES_ACCESS_KEY = os.environ.get('AWS_ES_ACCESS_KEY')
 AWS_ES_SECRET_KEY = os.environ.get('AWS_ES_SECRET_KEY')
-AWS_ES_HOST = os.environ.get('ES7_HOST')
-
+AWS_ES_HOST = os.environ.get('ES_HOST')
 
 _COMPLAINT_ES_INDEX = os.environ.get('COMPLAINT_ES_INDEX', 'complaint-index')
-_COMPLAINT_DOC_TYPE = os.environ.get('COMPLAINT_DOC_TYPE', 'complaint-doctype')
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Now that all public use of Elasticsearch is on version 7, we can drop
references to ES7 from code and variables.

The last surviving part is the `ES7_HOST` variable, which we needed to
update Django apps and CCDB5 code independently. Now we can use just `ES_HOST`.

Both vars will live in local and production environments until all code is
switched to use `ES_HOST`. After that, we'll retire the `ES7_HOST` var.

NOTE: This patch also drops the `COMPLAINT_DOC_TYPE` var, which is no longer used.