### PR TITLE
Reduce pagination depth to 1K

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -19,7 +19,7 @@ AGG_SUBPRODUCT_DEFAULT = 90
 # Pagination depth is the max hits that users can explore page by page.
 # The default result size matches the default for users of our search.
 # The trend_depth default limits display to 5 items in some Trends contexts.
-PAGINATION_DEPTH_DEFAULT = 10000
+PAGINATION_DEPTH_DEFAULT = 1000
 RESULT_SIZE_DEFAULT = 25
 RESULT_SIZE_OPTIONS = [10, 50, 100]
 TREND_DEPTH_DEFAULT = 5

--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -63,9 +63,9 @@ def build_trend_meta(response):
 
 def get_break_points(hits, size):
     """Return a dict of 'search-after' values for pagination."""
-    end_page = int(PAGINATION_DEPTH_DEFAULT / size) - 1
+    end_page = int(PAGINATION_DEPTH_DEFAULT / size)
     break_points = {}
-    if size > len(hits):
+    if size >= len(hits):
         return break_points
     # we don't need a break point for page 1; start with page 2
     page = 2


### PR DESCRIPTION
This reduces our pagination depth from 10,000 to 1,000, which
makes most List view searches 10X faster.

Users should see no difference, other than snappy searches.

This patch also fixes an off-by-one pagination error that was
leaving off the final page of 10,000 results.

### Testing
This is best tested in chrome with the Redux DevTools plugin:
- open dev tools and go to the Redux panel
- Run the default 3y search on the List tab, then look at the COMPLAINTS_RECEIVED filter, and choose
the Action tab.
- Look at the "break_points" value Under `data -> _meta`, and you should see
that, with the default results batch of 25 per page, you see 40 breakpoints,
not 400.
- If you do the same on www, you'll see 399, due to the off-by-1 error.