### PR TITLE
Allow efficient deep pagination to 10K hits

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -16,10 +16,12 @@ AGG_SUBISSUE_DEFAULT = 250
 AGG_PRODUCT_DEFAULT = 30
 AGG_SUBPRODUCT_DEFAULT = 90
 # Other defaults:
-# Pagination depth is the max hits that users can explore page by page.
-# The default result size matches the default for users of our search.
+# Pagination batch is the number of results we paginate at a time.
+# Max pagination depth is the farthest we'll paginate – 100 batches.
+# The default result size matches the front-end default for users.
 # The trend_depth default limits display to 5 items in some Trends contexts.
-PAGINATION_DEPTH_DEFAULT = 1000
+PAGINATION_BATCH = 100
+MAX_PAGINATION_DEPTH = 10000
 RESULT_SIZE_DEFAULT = 25
 RESULT_SIZE_OPTIONS = [10, 50, 100]
 TREND_DEPTH_DEFAULT = 5

--- a/complaint_search/tests/test_es_interface.py
+++ b/complaint_search/tests/test_es_interface.py
@@ -263,7 +263,7 @@ class EsInterfaceTest_Search(TestCase):
             "hits": {
                 "total": {"value": 10000},
                 "hits": fake_hits}}
-        response = search(size=2, search_after="1620752400004_4367497")
+        response = search(size=2, search_after="1620752400004_4367497", page=2)
         self.assertEqual(len(response.get("_meta").get("break_points")), 2)
 
     @mock.patch("complaint_search.es_interface._get_now")

--- a/complaint_search/tests/test_get_pagination_query_size.py
+++ b/complaint_search/tests/test_get_pagination_query_size.py
@@ -1,0 +1,54 @@
+import unittest
+
+from complaint_search.defaults import MAX_PAGINATION_DEPTH, PAGINATION_BATCH
+from complaint_search.es_interface import get_pagination_query_size
+
+
+class TestPaginationSize(unittest.TestCase):
+
+    def setUp(self):
+        self.user_sizes = [10, 25, 50, 100]
+
+    def test_get_pagination_query_size_page_1(self):
+        page = 1
+        for user_size in self.user_sizes[:3]:
+            self.assertEqual(
+                get_pagination_query_size(page, user_size),
+                PAGINATION_BATCH * 2
+            )
+        self.assertEqual(
+            get_pagination_query_size(page, 400),
+            600
+        )
+
+    def test_get_pagination_query_size_page_2(self):
+        page = 2
+        self.assertEqual(
+            get_pagination_query_size(page, 25),
+            PAGINATION_BATCH * 2
+        )
+        self.assertEqual(
+            get_pagination_query_size(page, 100),
+            PAGINATION_BATCH * 4
+        )
+
+    def test_get_pagination_query_size_with_remainder(self):
+        page = 6
+        self.assertEqual(
+            get_pagination_query_size(page, 25),
+            PAGINATION_BATCH * 4
+        )
+
+    def test_get_pagination_query_size_equals_max(self):
+        page = 100
+        self.assertEqual(
+            get_pagination_query_size(page, 100),
+            MAX_PAGINATION_DEPTH
+        )
+
+    def test_get_pagination_query_size_exceeds_max(self):
+        page = 101
+        self.assertEqual(
+            get_pagination_query_size(page, 100),
+            MAX_PAGINATION_DEPTH
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv=
 commands=
     coverage erase
     coverage run manage.py test {posargs}
-    coverage report
+    coverage report -m
     coverage html
 
 [testenv:lint]
@@ -50,4 +50,4 @@ sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [travis]
 python=
-  3.6: py36-dj22, lint
+  3.8: py38-dj22, lint


### PR DESCRIPTION
This change sets the default initial pagination depth to 200 for
fast initial searches, but allows users to explore as deeply as they
dare by progressively increasing the pagination depth by another
100 hits, as needed, up to 10K.

Searches will lose tiny amounts of speed as pagination goes deeper,
maxing out at around 6 seconds per "next page" request when a theoretical user
approaches 10,000 hits under the sea.

## Testing

You can test the deep pagination locally if you have a local complaint index
populated. But it's much simpler to test on DEV4, where it has been deployed and tested.  

CA has signed off on its testing there.

