### PR TITLE
switch from elasticsearch python library to opensearch-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Requirements are batch-installed via pip (see below).
 * django - Web framework
 * django-localflavor - Country-specific Django helpers
 * djangorestframework - Rest API framework
-* elasticsearch - low level client for Elasticsearch
+* opensearch-py - low level client for OpenSearch
 * requests - http requests to get different data format
 
 
 ## Setup & Running
-This repository assumes that you have an instance of elasticsearch running with complaint data set up and running.
+This repository assumes that you have an instance of opensearch or elasticsearch running with complaint data set up and running.
 
 ### Environment Variables
 This project uses environment variables and uses autoenv to automatically define environment variables and launch the virtualenv upon cding to the project folder.

--- a/complaint_search/decorators.py
+++ b/complaint_search/decorators.py
@@ -1,6 +1,6 @@
 import logging
 
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -16,7 +16,7 @@ def catch_es_error(function):
             log.error(te)
 
             status_code = 424  # HTTP_424_FAILED_DEPENDENCY
-            res = {"error": "There was an error calling Elasticsearch"}
+            res = {"error": "There was an error calling OpenSearch"}
             return Response(res, status=status_code)
         except Exception as e:
             log.error(e)

--- a/complaint_search/es_builders.py
+++ b/complaint_search/es_builders.py
@@ -75,7 +75,7 @@ class BaseBuilder(object):
         "zip_code",
     )
 
-    # Filters that use different names in Elasticsearch
+    # Filters that use different names in OpenSearch
     _OPTIONAL_FILTERS_PARAM_TO_ES_MAP = {
         "company_public_response": "company_public_response.raw",
         "company": "company.raw",
@@ -240,7 +240,7 @@ class BaseBuilder(object):
 
 class SearchBuilder(BaseBuilder):
     """
-    Assemble a JSON request to be sent to Elasticsearch.
+    Assemble a JSON request to be sent to OpenSearch.
 
     The builder begins with default PARAMS, adds params from a given
     search request, then adds options for highlighting and sorting.

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -6,7 +6,7 @@ from io import StringIO
 from django.http import StreamingHttpResponse
 
 
-class ElasticSearchExporter(object):
+class OpenSearchExporter(object):
 
     # export_csv - Stream an Elsticsearch response as a CSV file
     #
@@ -14,7 +14,7 @@ class ElasticSearchExporter(object):
     # - scanResponse (generator)
     #   The response from an Elasticsaerch scan query
     # - header_dict (OrderedDict)
-    #   The ordered dictionary where the key is the Elasticsearch field name
+    #   The ordered dictionary where the key is the OpenSearch field name
     #   and the value is the CSV column header for that field
     def export_csv(self, scanResponse, header_dict):
         def read_and_flush(writer, buffer_, row):
@@ -59,7 +59,7 @@ class ElasticSearchExporter(object):
     #
     # Parameters:
     # - scanResponse (generator)
-    #   The response from an Elasticsearch scan query
+    #   The response from an OpenSearch scan query
     # - total_count (int)
     #   The total number of records to be output
     def export_json(self, scanResponse, total_count):

--- a/complaint_search/tests/test_es_interface_states.py
+++ b/complaint_search/tests/test_es_interface_states.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 import mock
-from elasticsearch import Elasticsearch
+from opensearchpy import OpenSearch
 
 from complaint_search.es_interface import states_agg
 from complaint_search.tests.es_interface_test_helpers import (
@@ -12,8 +12,8 @@ from complaint_search.tests.es_interface_test_helpers import (
 
 class EsInterfaceTestStates(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "search")
-    @mock.patch.object(Elasticsearch, "count")
+    @mock.patch.object(OpenSearch, "search")
+    @mock.patch.object(OpenSearch, "count")
     def test_states__valid(self, mock_count, mock_search):
         mock_count.return_value = {"count": 100}
         body = load("states_agg__valid")
@@ -29,8 +29,8 @@ class EsInterfaceTestStates(TestCase):
         self.assertEqual(res["hits"]["total"]["relation"], "eq")
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "search")
-    @mock.patch.object(Elasticsearch, "count")
+    @mock.patch.object(OpenSearch, "search")
+    @mock.patch.object(OpenSearch, "count")
     def test_states_exclude__valid(self, mock_count, mock_search):
         body = load("states_agg__valid")
         mock_search.return_value = {
@@ -45,7 +45,7 @@ class EsInterfaceTestStates(TestCase):
         self.assertEqual(res["hits"]["total"]["relation"], "eq")
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "search")
     def test_states_date_filters__valid(self, mock_search):
         params = {
             "date_received_min": "2020-01-01",

--- a/complaint_search/tests/test_es_interface_trends.py
+++ b/complaint_search/tests/test_es_interface_trends.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 import mock
-from elasticsearch import Elasticsearch
+from opensearchpy import OpenSearch
 
 from complaint_search.es_interface import trends
 from complaint_search.tests.es_interface_test_helpers import load
@@ -9,8 +9,8 @@ from complaint_search.tests.es_interface_test_helpers import load
 
 class EsInterfaceTestTrends(TestCase):
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_default_params__valid(self, mock_search, mock_count):
         trends_params = {"lens": "overview", "trend_interval": "year"}
         body = load("trends_default_params__valid")
@@ -22,8 +22,8 @@ class EsInterfaceTestTrends(TestCase):
         self.assertEqual(body, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_sub_lens_product__valid(self, mock_search, mock_count):
         trends_params = {
             "lens": "product",
@@ -42,8 +42,8 @@ class EsInterfaceTestTrends(TestCase):
         self.assertEqual(body, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_exclude_and_date_filters__valid(
         self, mock_search, mock_count
     ):
@@ -65,8 +65,8 @@ class EsInterfaceTestTrends(TestCase):
         self.assertEqual(body, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_filter__valid(self, mock_search, mock_count):
         trends_params = {
             "lens": "product",
@@ -86,8 +86,8 @@ class EsInterfaceTestTrends(TestCase):
         self.assertEqual(body, res)
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_top_self_filter__valid(self, mock_search, mock_count):
         trends_params = {
             "lens": "overview",
@@ -106,8 +106,8 @@ class EsInterfaceTestTrends(TestCase):
         self.assertTrue("company" not in res["aggregations"])
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_company_filter__valid(self, mock_search, mock_count):
         default_exclude = ["company", "zip_code"]
         trends_params = {
@@ -126,8 +126,8 @@ class EsInterfaceTestTrends(TestCase):
         self.assertTrue("company" in res["aggregations"])
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_issue_focus__valid(self, mock_search, mock_count):
         default_exclude = ["company", "zip_code"]
         trends_params = {
@@ -150,8 +150,8 @@ class EsInterfaceTestTrends(TestCase):
         )
 
     @mock.patch("complaint_search.es_interface._COMPLAINT_ES_INDEX", "INDEX")
-    @mock.patch.object(Elasticsearch, "count")
-    @mock.patch.object(Elasticsearch, "search")
+    @mock.patch.object(OpenSearch, "count")
+    @mock.patch.object(OpenSearch, "search")
     def test_trends_issue_focus_company_filter__valid(
         self, mock_search, mock_count
     ):

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 from parameterized import parameterized
 
-from complaint_search.export import ElasticSearchExporter
+from complaint_search.export import OpenSearchExporter
 
 
 TEST_HEADERS = OrderedDict(
@@ -39,7 +39,7 @@ class ExportTest(TestCase):
     @parameterized.expand([[10], [5010], [100000]])
     def test_export_csv_request_response(self, length):
         # arrange
-        es_exporter = ElasticSearchExporter()
+        es_exporter = OpenSearchExporter()
         gen = es_generator(length)
 
         # act
@@ -59,7 +59,7 @@ class ExportTest(TestCase):
     @parameterized.expand([[10], [5010], [100000]])
     def test_export_json_request_response(self, length):
         # arrange
-        es_exporter = ElasticSearchExporter()
+        es_exporter = OpenSearchExporter()
         gen = es_generator(length)
 
         # act
@@ -92,7 +92,7 @@ class TestCSVExportWithUnicodeCharacters(TestCase):
                 },
             }
 
-        exporter = ElasticSearchExporter()
+        exporter = OpenSearchExporter()
         response = exporter.export_csv(unicode_results(), headers)
         content = io.BytesIO(b"".join(response.streaming_content)).read()
         self.assertEqual(content, b"Key\r\n\xe2\x80\x99\r\n")

--- a/complaint_search/tests/test_view_suggest_company.py
+++ b/complaint_search/tests/test_view_suggest_company.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.urls import reverse
 
 import mock
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -70,6 +70,6 @@ class SuggestCompanyTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error calling Elasticsearch"},
+            {"error": "There was an error calling OpenSearch"},
             response.data,
         )

--- a/complaint_search/tests/test_views_document.py
+++ b/complaint_search/tests/test_views_document.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.test import override_settings
 
 import mock
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -88,6 +88,6 @@ class DocumentTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error calling Elasticsearch"},
+            {"error": "There was an error calling OpenSearch"},
             response.data,
         )

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -7,7 +7,7 @@ from django.http import StreamingHttpResponse
 from django.test import override_settings
 
 import mock
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APITestCase
@@ -916,7 +916,7 @@ class SearchTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error calling Elasticsearch"},
+            {"error": "There was an error calling OpenSearch"},
             response.data,
         )
 

--- a/complaint_search/tests/test_views_suggest.py
+++ b/complaint_search/tests/test_views_suggest.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 import mock
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -105,6 +105,6 @@ class SuggestTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error calling Elasticsearch"},
+            {"error": "There was an error calling OpenSearch"},
             response.data,
         )

--- a/complaint_search/tests/test_views_suggest_company.py
+++ b/complaint_search/tests/test_views_suggest_company.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 import mock
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -75,6 +75,6 @@ class SuggestCompanyTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error calling Elasticsearch"},
+            {"error": "There was an error calling OpenSearch"},
             response.data,
         )

--- a/complaint_search/tests/test_views_suggest_zip.py
+++ b/complaint_search/tests/test_views_suggest_zip.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 import mock
-from elasticsearch import TransportError
+from opensearchpy import TransportError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -75,6 +75,6 @@ class SuggestZipTests(APITestCase):
         response = self.client.get(url, param)
         self.assertEqual(response.status_code, 424)
         self.assertDictEqual(
-            {"error": "There was an error calling Elasticsearch"},
+            {"error": "There was an error calling OpenSearch"},
             response.data,
         )

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     "djangorestframework>=3.9.1,<4.0",
     "django-rest-swagger>=2.2.0",
     "requests>=2.18,<3",
-    "elasticsearch>=7.0.0,<7.11",
+    "opensearch-py==1.1.0",
     "django-localflavor>=1.1,<3.1",
     "django-flags>=4.0.1,<5.1",
     "requests-aws4auth",
@@ -65,7 +65,6 @@ testing_extras = [
     "deepdiff>=3.3,<5.0",
     "django-nose==1.4.1",
     "parameterized==0.6.1",
-    "elasticsearch7>=7.0.0,<8.0.0",
     "requests-aws4auth",
 ]
 

--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -560,7 +560,7 @@ components:
   schemas:
     Aggregation:
       type: object
-      description: An Elasticsearch aggregation
+      description: An OpenSearch aggregation
       properties:
         doc_count:
           type: integer
@@ -663,7 +663,7 @@ components:
           description: The mailing ZIP code provided by the consumer
     Hit:
       type: object
-      description: A single Elasticsearch result
+      description: A single OpenSearch result
       properties:
         _source:
           $ref: '#/components/schemas/Complaint'


### PR DESCRIPTION
This changes the backend python libraries from ElasticSearch to OpenSearch. This does not change any functionality within ccdb5-api, only how complaints are indexed using the backend libs.