### PR TITLE
Fix flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,10 +9,8 @@ ignore =
     # PEP8 weakly recommends Knuth-style line breaks before binary
     # operators
     W503, W504
-exclude =
+extend-exclude =
     # These are directories that it's a waste of time to traverse
-    .git,
-    .tox,
     .venv,
     docs,
     venv,
@@ -20,4 +18,4 @@ exclude =
     # Generated migration files will throw errors. We need to find a way
     # to exclude django-generated migrations while including
     # manually-written migrations.
-    */migrations/*.py,
+    **/migrations/*.py,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def format_version(version, fmt=fmt):
 
     # This is an unknown fork/branch being run in the CI
     if len(parts) == 1:
-        return fmt.format(tag="ci", commitcount=0, gitsha=version)
+        return fmt.format(tag="0", commitcount=0, gitsha=version)
 
     # Sometimes the closest tag has '-dev' and messes everything up
     if len(parts) == 5 and parts[1] == "dev":

--- a/tox.ini
+++ b/tox.ini
@@ -27,14 +27,6 @@ commands=
     flake8 ccdb5_api complaint_search
     isort --check-only --diff ccdb5_api complaint_search
 
-[flake8]
-ignore = E731, W503, W504,
-exclude =
-    .git,
-    .tox,
-    __pycache__,
-    */migrations/*.py,
-
 [isort]
 line_length=78
 include_trailing_comma=1


### PR DESCRIPTION
"tox -e lint" was failing on this repository. There were multiple conflicting configurations for flake8 in .flake8 and tox.ini.

This commit simplifies so that the configuration only lives in .flake8, and works again even on the latest version of flake8.

See also https://github.com/cfpb/wagtail-inventory/pull/61 and https://github.com/cfpb/wagtail-sharing/pull/58.