### PR TITLE
Deprecate Django support before version 3.2

### DIFF
--- a/ccdb5_api/urls.py
+++ b/ccdb5_api/urls.py
@@ -1,6 +1,4 @@
 from django.contrib import admin
-
-
 from django.urls import include, re_path
 
 

--- a/ccdb5_api/urls.py
+++ b/ccdb5_api/urls.py
@@ -1,25 +1,7 @@
-"""ccdb5_api URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/stable/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
 from django.contrib import admin
 
 
-try:
-    from django.urls import include, re_path
-except ImportError:
-    from django.conf.urls import include
-    from django.conf.urls import url as re_path
+from django.urls import include, re_path
 
 
 urlpatterns = [

--- a/complaint_search/urls.py
+++ b/complaint_search/urls.py
@@ -1,13 +1,9 @@
-from django.conf.urls import url
 from django.views.generic.base import RedirectView
 
 import complaint_search.views
 
 
-try:
-    from django.urls import re_path
-except ImportError:
-    from django.conf.urls import url as re_path
+from django.urls import re_path
 
 
 app_name = "complaint_search"
@@ -27,8 +23,8 @@ urlpatterns = [
     re_path(
         r"^(?P<id>[0-9]+)$", complaint_search.views.document, name="complaint"
     ),
-    url(r"^$", complaint_search.views.search, name="search"),
-    url(r"^geo/states", complaint_search.views.states, name="states"),
-    url(r"^geo", RedirectView.as_view(url="/geo/states"), name="geo"),
-    url(r"^trends", complaint_search.views.trends, name="trends"),
+    re_path(r"^$", complaint_search.views.search, name="search"),
+    re_path(r"^geo/states", complaint_search.views.states, name="states"),
+    re_path(r"^geo", RedirectView.as_view(url="/geo/states"), name="geo"),
+    re_path(r"^trends", complaint_search.views.trends, name="trends"),
 ]

--- a/complaint_search/urls.py
+++ b/complaint_search/urls.py
@@ -1,9 +1,7 @@
+from django.urls import re_path
 from django.views.generic.base import RedirectView
 
 import complaint_search.views
-
-
-from django.urls import re_path
 
 
 app_name = "complaint_search"

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
 
 
 install_requires = [
-    "Django>=1.11,<3.3",
+    "Django>=3.2,<3.3",
     "djangorestframework>=3.9.1,<4.0",
     "django-rest-swagger>=2.2.0",
     "requests>=2.18,<3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 skipsdist=True
-envlist=lint,py{38}-dj{22,32}
+envlist=lint,py{38}-dj{32}
 
 [testenv]
 basepython=
     py38: python3.8
 deps=
-    dj22: Django>=2.2,<2.3
     dj32: Django>=3.2,<3.3
 
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -50,4 +49,4 @@ sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [travis]
 python=
-  3.8: py38-dj22, lint
+  3.8: py38-dj32, lint


### PR DESCRIPTION
This commit removes support for versions of Django before 3.2. This allows for removal of several try/except ImportError clauses and migration away from the deprecated `url` method in favor of `re_path`. This fixes the following Django deprecation warning:

> RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().

Note that the linter CI check will fail on this PR; a separate fix for that is in #195.