### PR TITLE
DATAP-1733: Update packages and tests

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,6 +1,6 @@
 backports-abc==0.5
 click==8.1.3
-Django==4.2.21
+Django==4.2.22
 django-rest-swagger==2.2.0
 djangorestframework==3.15.2
 elasticsearch==7.10.1
@@ -10,4 +10,4 @@ MarkupSafe==2.0.1
 mkdocs==1.2.3
 mkDOCter==1.0.5
 PyYAML==6.0
-tornado==4.5.3
+tornado==6.5.1

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -2,7 +2,7 @@ backports-abc==0.5
 click==8.1.3
 Django==4.2.21
 django-rest-swagger==2.2.0
-djangorestframework==3.15.12
+djangorestframework==3.15.2
 elasticsearch==7.10.1
 Jinja2==2.11.3
 Markdown==3.3.6

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -4,7 +4,7 @@ Django==4.2.22
 django-rest-swagger==2.2.0
 djangorestframework==3.15.2
 elasticsearch==7.10.1
-Jinja2==2.11.3
+Jinja2==3.1.6
 Markdown==3.3.6
 MarkupSafe==2.0.1
 mkdocs==1.2.3

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,8 +1,8 @@
 backports-abc==0.5
 click==8.1.3
-Django==3.2.17
+Django==5.1.10
 django-rest-swagger==2.2.0
-djangorestframework==3.14.0
+djangorestframework==3.15.12
 elasticsearch==7.10.1
 Jinja2==2.11.3
 Markdown==3.3.6

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,6 +1,6 @@
 backports-abc==0.5
 click==8.1.3
-Django==5.1.10
+Django==4.2.21
 django-rest-swagger==2.2.0
 djangorestframework==3.15.12
 elasticsearch==7.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Django==4.2.21
+djangorestframework==3.15.2
+django-rest-swagger==2.2.0
+requests==2.32.4
+elasticsearch==7.10.1
+django-localflavor
+django-flags==5.0.14
+requests-aws4auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.21
+Django==4.2.22
 djangorestframework==3.15.2
 django-rest-swagger==2.2.0
 requests==2.32.4

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
 
 
 install_requires = [
-    "Django>=4.2,<=5.2",
+    "Django>=4.2,<=4.3",
     "djangorestframework>=3.15.2,<4.0",
     "django-rest-swagger>=2.2.0",
     "requests>=2.32.4,<3",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
 
 
 install_requires = [
-    "Django>=4.2,<=4.3",
+    "Django>=4.2,<4.3",
     "djangorestframework>=3.15.2,<4.0",
     "django-rest-swagger>=2.2.0",
     "requests>=2.32.4,<3",

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,11 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
 
 
 install_requires = [
-    "Django>=3.2,<4.3",
-    "djangorestframework>=3.14,<4.0",
+    "Django>=4.2,<=5.2",
+    "djangorestframework>=3.15.2,<4.0",
     "django-rest-swagger>=2.2.0",
-    "requests>=2.31,<3",
-    "elasticsearch>=7.0.0,<7.11",
+    "requests>=2.32.4,<3",
+    "elasticsearch>=7.10.1,<7.11",
     "django-localflavor>=4.0,<5.0",
     "django-flags>=4.0.1,<5.1",
     "requests-aws4auth",
@@ -62,9 +62,8 @@ testing_extras = [
     "coverage>=7.4,<8",
     "deep==0.10",
     "deepdiff>=6.7,<7",
-    "django-nose==1.4.7",
     "parameterized==0.9.0",
-    "elasticsearch7>=7.0.0,<8.0.0",
+    "elasticsearch7>=7.1.0,<7.11",
     "requests-aws4auth",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands=
     coverage html
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.9
 deps=
     flake8
     isort == 5.9.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 skipsdist=True
-envlist=lint,py38-dj{32,42}
+envlist=lint,py38-dj42
 
 [testenv]
 basepython=python3.8
 deps=
-    dj32: Django>=3.2,<3.3
     dj42: Django>=4.2,<4.3
 
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 skipsdist=True
-envlist=lint,py38-dj42
+envlist=lint,py39-dj42
 
 [testenv]
-basepython=python3.8
+basepython=python3.9
 deps=
     dj42: Django>=4.2,<4.3
 
@@ -40,4 +40,4 @@ sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [travis]
 python=
-  3.8: py38-dj32, lint
+  3.9: py39-dj42, lint


### PR DESCRIPTION
The CCDB API requirements had been neglected for some time. This PR brings dependencies up to date with the host cfgov framework, and restores the tox tests, which now pass.

Added files;
reqirements.txt file for local development and testing.

Note:
The API is limited to Python 3.8 because of restrictions on the current cfgov deployment environment. That also affects which version of Django we can use (can't move to Django 5).

We'll want to run this on a dev server to confirm.