### PR TITLE
Update the release action to download Python 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
+          check-latest: false
+          update-environment: true
+          freethreaded: false
+        env:
+          LD_LIBRARY_PATH: /usr/local/lib
 
       - name: Install Python dependencies
         run: python -m pip install --upgrade pip wheel


### PR DESCRIPTION
We have to stay even with the Python version used in cfgov, since we deploy inside that project. cfgov is pinned at 3.8 at present because of deployment infrastructure. But 3.8 is no longer available as an import, and our release fails to build a wheel.

The new script code mirrors how cfgov configures its releases to download 3.8.