### PR TITLE
Fix release wheel builds/uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  pull_request:
   release:
     types: [published]
 
@@ -11,12 +12,12 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.13
 
       - name: Install Python dependencies
-        run: python -m pip install --upgrade pip wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Build the packages
         id: build
@@ -27,6 +28,7 @@ jobs:
           echo "::set-output name=bdist_wheel::$(cd dist && ls *.whl)"
 
       - name: Upload the wheel
+        if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub Action that builds wheels on releases has been broken for some time due to Python 3.8's EOL, see for example https://github.com/cfpb/ccdb5-api/actions/runs/17275449040

This commit updates the release building code to use a more modern version of Python (3.13) - we don't need to use the runtime version of Python (3.8) to build the wheel.

It also updates the action to run on pull requests to ensure that the release package can be built (without actually doing the upload).