### PR TITLE
Avoid server errors when aggregations 'max_indexed_date' is null

### DIFF
--- a/complaint_search/es_interface.py
+++ b/complaint_search/es_interface.py
@@ -219,19 +219,18 @@ def _get_meta():
 
     result = {
         "license": "CC0",
-        "last_updated": max_date_res["aggregations"]["max_date"][
+        "last_updated": max_date_res["aggregations"]["max_date"].get(
             "value_as_string"
-        ],
-        "last_indexed": max_date_res["aggregations"]["max_indexed_date"][
+        ),
+        "last_indexed": max_date_res["aggregations"]["max_indexed_date"].get(
             "value_as_string"
-        ],
+        ),
         "total_record_count": count_res["count"],
         "is_data_stale": _is_data_stale(
-            max_date_res["aggregations"]["max_date"]["value_as_string"]
+            max_date_res["aggregations"]["max_date"].get("value_as_string")
         ),
         "has_data_issue": bool(flag_enabled("CCDB_TECHNICAL_ISSUES")),
     }
-
     return result
 
 


### PR DESCRIPTION
Python key errors can occur when running the CCDB API in local cfgov environments with small test-loads of data, because our code assumes that Elasticsearch/Opensearch always returns a `value_as_string` value for max_indexed_date and max_date. Key errors throw a server 500.

If we use Python's "get" method to harvest value_as_string, instead of calling the `value_as_string` key directly, the code will return null instead of causing a 500 server error.

This should not affect normal operations.