### PR TITLE
Remove the upper bound on Django-Flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     "requests>=2.32.4,<3",
     "opensearch-py>=2.1.0,<=3.0.0",
     "django-localflavor>=4.0,<5.0",
-    "django-flags>=4.0.1,<5.1",
+    "django-flags>=5",
     "requests-aws4auth",
 ]
 


### PR DESCRIPTION
Now that Django-Flags 5.1 exists, this upper bound is preventing us from updating. I'm choosing to remove it here since this is a library we control, to avoid future issues.