### PR TITLE
Delete deprecated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-Django==5.2.9
-djangorestframework==3.15.2
-django-localflavor
-django-flags==5.0.14
-opensearch-py==3.0.0
-requests==2.32.4
-requests-aws4auth


### PR DESCRIPTION
The requirements.txt file is no longer used. Requirements are specified in setup.py.

See internal explorer-docs#3008 for context.