### PR TITLE
Increase size param now that data is larger

### DIFF
--- a/complaint_search/serializer.py
+++ b/complaint_search/serializer.py
@@ -48,7 +48,7 @@ class SearchInputSerializer(serializers.Serializer):
     format = serializers.ChoiceField(FORMAT_CHOICES, default=PARAMS["format"])
     field = serializers.ChoiceField(FIELD_CHOICES, default=PARAMS["field"])
     size = serializers.IntegerField(
-        min_value=0, max_value=10000000, default=PARAMS["size"]
+        min_value=0, max_value=20000000, default=PARAMS["size"]
     )
     frm = serializers.IntegerField(
         min_value=0, max_value=10000, default=PARAMS["frm"]

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -214,13 +214,13 @@ class SearchTests(APITestCase):
     @mock.patch("complaint_search.es_interface.search")
     def test_search_with_size__invalid_exceed_max_number(self, mock_essearch):
         url = reverse("complaint_search:search")
-        params = {"size": 10000001}
+        params = {"size": 20000001}
         mock_essearch.return_value = "OK"
         response = self.client.get(url, params)
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_essearch.assert_not_called()
         self.assertDictEqual(
-            {"size": ["Ensure this value is less than or equal to 10000000."]},
+            {"size": ["Ensure this value is less than or equal to 20000000."]},
             response.data,
         )
 


### PR DESCRIPTION
This will prevent 400s from exports of the default filter set.