### PR TITLE
limit JSON downloads to the 100K max

### DIFF
--- a/complaint_search/defaults.py
+++ b/complaint_search/defaults.py
@@ -21,6 +21,7 @@ AGG_SUBPRODUCT_DEFAULT = 90
 # The default result size matches the front-end default for users.
 # The trend_depth default limits display to 5 items in some Trends contexts.
 PAGINATION_BATCH = 100
+MAX_DOWNLOAD_SIZE = 100000
 MAX_PAGINATION_DEPTH = 10000
 RESULT_SIZE_DEFAULT = 25
 RESULT_SIZE_OPTIONS = [10, 50, 100]

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -8,6 +8,7 @@ from django.http.response import Http404
 
 from complaint_search.defaults import MAX_DOWNLOAD_SIZE
 
+
 class OpenSearchExporter(object):
 
     # export_csv - Stream an OpenSearch response as a CSV file
@@ -66,7 +67,8 @@ class OpenSearchExporter(object):
     #   The total number of records to be output
     def export_json(self, scanResponse, total_count):
         if not total_count or total_count > MAX_DOWNLOAD_SIZE:
-            raise Http404
+            return Http404
+
         def stream():
             count = 0
             # Write JSON

--- a/complaint_search/export.py
+++ b/complaint_search/export.py
@@ -4,7 +4,9 @@ from csv import DictWriter
 from io import StringIO
 
 from django.http import StreamingHttpResponse
+from django.http.response import Http404
 
+from complaint_search.defaults import MAX_DOWNLOAD_SIZE
 
 class OpenSearchExporter(object):
 
@@ -63,6 +65,8 @@ class OpenSearchExporter(object):
     # - total_count (int)
     #   The total number of records to be output
     def export_json(self, scanResponse, total_count):
+        if not total_count or total_count > MAX_DOWNLOAD_SIZE:
+            raise Http404
         def stream():
             count = 0
             # Write JSON

--- a/complaint_search/tests/test_export.py
+++ b/complaint_search/tests/test_export.py
@@ -4,10 +4,12 @@ import io
 from collections import OrderedDict
 
 from django.http import StreamingHttpResponse
+from django.http.response import Http404
 from django.test import TestCase
 
 from parameterized import parameterized
 
+from complaint_search.defaults import MAX_DOWNLOAD_SIZE
 from complaint_search.export import OpenSearchExporter
 
 
@@ -75,6 +77,13 @@ class ExportTest(TestCase):
         self.assertTrue("map" in str(type(res.streaming_content)))
         downloaded_file = io.BytesIO(b"".join(res.streaming_content))
         self.assertFalse(downloaded_file is None)
+
+    def test_json_export_limit(self):
+        length = MAX_DOWNLOAD_SIZE + 1
+        es_exporter = OpenSearchExporter()
+        gen = es_generator(length)
+        es_exporter.export_json(gen, length)
+        self.assertRaises(Http404)
 
 
 class TestCSVExportWithUnicodeCharacters(TestCase):


### PR DESCRIPTION
Add a limit to the JSON download option, which will soon go away entirely.
~~But need to add a test.~~